### PR TITLE
Make sure login form inputs get focused and cleared before typing

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -18,6 +18,6 @@
  */
 export const login = (username = 'admin', password = 'password'): void => {
   cy.visit('wp-login.php');
-  cy.get('input#user_login').type(username);
-  cy.get('input#user_pass').type(`${password}{enter}`);
+  cy.get('input#user_login').click().clear().type(username);
+  cy.get('input#user_pass').click().clear().type(`${password}{enter}`);
 };


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->
Closes #11 
Clicking and clearing both inputs on the login form before typing.

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
