### PR TITLE
Document Settings tab and panel commands

### DIFF
--- a/src/commands/open-document-settings-panel.ts
+++ b/src/commands/open-document-settings-panel.ts
@@ -1,0 +1,32 @@
+/**
+ * Open Document Settings Panel
+ *
+ * @param name - Panel name
+ * @param tab - Settings tab
+ *
+ * @example
+ * Open featured image panel of the Post editor
+ * ```
+ * cy.openDocumentSettingsPanel('Featured image')
+ * ```
+ *
+ * @example
+ * Open Permalink panel of the Page editor
+ * ```
+ * cy.openDocumentSettingsPanel('Permalink', 'Page')
+ * ```
+ */
+export const openDocumentSettingsPanel = (name: string, tab = 'Post'): void => {
+  cy.openDocumentSettingsSidebar(tab);
+  cy.get('.components-panel__body .components-panel__body-title button')
+    .contains(name)
+    .then($button => {
+      const $panel = $button.parents('.components-panel__body');
+      if (!$panel.hasClass('is-opened')) {
+        cy.wrap($button).click();
+        cy.wrap($button)
+          .parents('.components-panel__body')
+          .should('have.class', 'is-opened');
+      }
+    });
+};

--- a/src/commands/open-document-settings-panel.ts
+++ b/src/commands/open-document-settings-panel.ts
@@ -17,11 +17,16 @@
  * ```
  */
 export const openDocumentSettingsPanel = (name: string, tab = 'Post'): void => {
+  // Open Settings tab
   cy.openDocumentSettingsSidebar(tab);
+
   cy.get('.components-panel__body .components-panel__body-title button')
     .contains(name)
     .then($button => {
+      // Find the panel container
       const $panel = $button.parents('.components-panel__body');
+
+      // Only click the button if the panel is collapsed
       if (!$panel.hasClass('is-opened')) {
         cy.wrap($button).click();
         cy.wrap($button)

--- a/src/commands/open-document-settings-sidebar.ts
+++ b/src/commands/open-document-settings-sidebar.ts
@@ -1,0 +1,27 @@
+/**
+ * Open Document Settings Sidebar
+ *
+ * @param tab - Name of the tab
+ *
+ * @example
+ * Open 'Post' tab
+ * ```
+ * cy.openDocumentSettingsSidebar()
+ * ```
+ *
+ * @example
+ * Open 'Block' tab
+ * ```
+ * cy.openDocumentSettingsSidebar('Block')
+ * ```
+ */
+export const openDocumentSettingsSidebar = (tab = 'Post'): void => {
+  const button =
+    '.edit-post-header__settings button[aria-label="Settings"][aria-expanded="false"]';
+  cy.get('body').then($body => {
+    if ($body.find(button).length > 0) {
+      cy.get(button).click();
+    }
+  });
+  cy.get('.edit-post-sidebar__panel-tab').contains(tab).click();
+};

--- a/src/commands/open-document-settings-sidebar.ts
+++ b/src/commands/open-document-settings-sidebar.ts
@@ -16,6 +16,7 @@
  * ```
  */
 export const openDocumentSettingsSidebar = (tab = 'Post'): void => {
+  // Open the sidebar if it is collapsed
   const button =
     '.edit-post-header__settings button[aria-label="Settings"][aria-expanded="false"]';
   cy.get('body').then($body => {
@@ -23,5 +24,7 @@ export const openDocumentSettingsSidebar = (tab = 'Post'): void => {
       cy.get(button).click();
     }
   });
+
+  // Click the tab
   cy.get('.edit-post-sidebar__panel-tab').contains(tab).click();
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 /// <reference types="cypress" />
 
 // Import commands.
+import { openDocumentSettingsPanel } from './commands/open-document-settings-panel';
 import { openDocumentSettingsSidebar } from './commands/open-document-settings-sidebar';
 import { deleteAllTerms } from './commands/delete-all-terms';
 import { createTerm } from './commands/create-term';
@@ -11,6 +12,7 @@ import { login } from './commands/login';
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {
+      openDocumentSettingsPanel: typeof openDocumentSettingsPanel;
       openDocumentSettingsSidebar: typeof openDocumentSettingsSidebar;
       deleteAllTerms: typeof deleteAllTerms;
       createTerm: typeof createTerm;
@@ -21,6 +23,7 @@ declare global {
 }
 
 // Register commands
+Cypress.Commands.add('openDocumentSettingsPanel', openDocumentSettingsPanel);
 Cypress.Commands.add(
   'openDocumentSettingsSidebar',
   openDocumentSettingsSidebar

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 /// <reference types="cypress" />
 
 // Import commands.
+import { openDocumentSettingsSidebar } from './commands/open-document-settings-sidebar';
 import { deleteAllTerms } from './commands/delete-all-terms';
 import { createTerm } from './commands/create-term';
 import { logout } from './commands/logout';
@@ -10,6 +11,7 @@ import { login } from './commands/login';
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {
+      openDocumentSettingsSidebar: typeof openDocumentSettingsSidebar;
       deleteAllTerms: typeof deleteAllTerms;
       createTerm: typeof createTerm;
       logout: typeof logout;
@@ -19,6 +21,10 @@ declare global {
 }
 
 // Register commands
+Cypress.Commands.add(
+  'openDocumentSettingsSidebar',
+  openDocumentSettingsSidebar
+);
 Cypress.Commands.add('deleteAllTerms', deleteAllTerms);
 Cypress.Commands.add('createTerm', createTerm);
 Cypress.Commands.add('logout', logout);

--- a/tests/cypress/integration/open-document-settings-panel.test.js
+++ b/tests/cypress/integration/open-document-settings-panel.test.js
@@ -1,0 +1,64 @@
+describe('Command: openDocumentSettingsPanel', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it("Should be able to open (don't close) Status Panel on a new post", () => {
+    cy.visit(`/wp-admin/post-new.php`);
+    cy.get('button[aria-label="Close dialog"]').click();
+
+    const name = 'Status & visibility';
+    cy.openDocumentSettingsPanel(name);
+
+    // Assertion: Stick to the top checkbox should be visible
+    cy.get('.components-panel__body .components-panel__body-title button')
+      .contains(name)
+      .then($button => {
+        const $panel = $button.parents('.components-panel__body');
+        cy.wrap($panel).should('contain', 'Stick to the top of the blog');
+      });
+  });
+
+  it('Should be able to open Tags panel on the existing post', () => {
+    cy.visit(`/wp-admin/edit.php?post_type=post`);
+    cy.get('#the-list .row-title').first().click();
+    cy.get('button[aria-label="Close dialog"]').click();
+
+    cy.get('.is-root-container.block-editor-block-list__layout > *')
+      .first()
+      .click();
+
+    const name = 'Tags';
+    cy.openDocumentSettingsPanel(name);
+
+    // Assertion: Add new tag input should be visible
+    cy.get('.components-panel__body .components-panel__body-title button')
+      .contains(name)
+      .then($button => {
+        const $panel = $button.parents('.components-panel__body');
+        cy.wrap($panel).should('contain', 'Add New Tag');
+      });
+  });
+
+  it('Should be able to open Discussion panel on the existing page', () => {
+    cy.visit(`/wp-admin/edit.php?post_type=page`);
+    cy.get('#the-list .row-title').first().click();
+    cy.get('button[aria-label="Close dialog"]').click();
+
+    cy.get('.is-root-container.block-editor-block-list__layout > *')
+      .first()
+      .click();
+
+    const name = 'Discussion';
+    cy.openDocumentSettingsPanel(name, 'Page');
+
+    // Assertion: Allow comments checkbox should be visible
+    cy.get('.components-panel__body .components-panel__body-title button')
+      .contains(name)
+      .then($button => {
+        const $panel = $button.parents('.components-panel__body');
+        cy.wrap($panel).should('contain', 'Allow comments');
+      });
+  });
+
+});

--- a/tests/cypress/integration/open-document-settings-sidebar.test.js
+++ b/tests/cypress/integration/open-document-settings-sidebar.test.js
@@ -1,0 +1,58 @@
+describe('Command: openDocumentSettingsSidebar', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('Should be able to Open Post Settings Sidebar on a new Post', () => {
+    cy.visit(`/wp-admin/post-new.php`);
+    cy.get('button[aria-label="Close dialog"]').click();
+    cy.openDocumentSettingsSidebar();
+
+    // Assertions:
+    cy.get('.edit-post-sidebar__panel-tab')
+      .contains('Post')
+      .should('have.class', 'is-active');
+    cy.get('.components-panel .components-panel__body').should(
+      'be.visible'
+    );
+  });
+
+  it('Should be able to Open Block tab of the first block on existing post', () => {
+    cy.visit(`/wp-admin/edit.php?post_type=post`);
+    cy.get('#the-list .row-title').first().click();
+    cy.get('button[aria-label="Close dialog"]').click();
+
+    cy.get('.is-root-container.block-editor-block-list__layout > *')
+      .first()
+      .click();
+    cy.openDocumentSettingsSidebar('Block');
+
+    // Assertions:
+    cy.get('.edit-post-sidebar__panel-tab')
+      .contains('Block')
+      .should('have.class', 'is-active');
+    cy.get('.components-panel .block-editor-block-inspector').should(
+      'be.visible'
+    );
+  });
+
+  it('Should be able to open Page Settings sidebar on an existing page', () => {
+    cy.visit(`/wp-admin/edit.php?post_type=page`);
+    cy.get('#the-list .row-title').first().click();
+    cy.get('button[aria-label="Close dialog"]').click();
+
+    cy.get('.is-root-container.block-editor-block-list__layout > *')
+      .first()
+      .click();
+
+    cy.openDocumentSettingsSidebar('Page');
+
+    // Assertions:
+    cy.get('.edit-post-sidebar__panel-tab')
+      .contains('Page')
+      .should('have.class', 'is-active');
+    cy.get('.components-panel .components-panel__body').should(
+      'be.visible'
+    );
+  })
+});


### PR DESCRIPTION
### Description of the Change

Adds new commands:
- `openDocumentSettingsSidebar` will open the tab in sidebar by it's name (Default is 'Post' tab)
- `openDocumentSettingsPanel` will open the panel inside the tab if it's not opened yet.

Relateed to #5, #7 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Added - openDocumentSettingsSidebar command
Added - openDocumentSettingsPanel command

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic
