### PR TITLE
Add options for createTerm

### DIFF
--- a/src/commands/create-term.ts
+++ b/src/commands/create-term.ts
@@ -3,6 +3,11 @@
  *
  * @param name - Term name
  * @param taxonomy - Taxonomy
+ * @param options {
+ *          slug - Taxonomy slug
+ *          parent - Parent taxonomy (ID or name)
+ *          description - Taxonomy description
+ *        }
  *
  * @example
  * Create new category with default name "Test category"
@@ -21,11 +26,42 @@
  * ```
  * cy.createTerm('Product name', 'product')
  * ```
+ *
+ * @example
+ * Create child category for existing Parent with custom description and slug
+ * ```
+ * cy.createTerm('Child', 'category', {
+ *   parent: 'Parent',
+ *   slug: 'child-slug',
+ *   description: 'Custom description'
+ * })
+ * ```
  */
 export const createTerm = (
   name = 'Test category',
-  taxonomy = 'category'
+  taxonomy = 'category',
+  {
+    slug = '',
+    parent = -1,
+    description = '',
+  }: { slug?: string; parent?: number | string; description?: string } = {}
 ): void => {
   cy.visit(`/wp-admin/edit-tags.php?taxonomy=${taxonomy}`);
-  cy.get('#tag-name').click().type(`${name}{enter}`);
+  cy.get('#tag-name').click().type(`${name}`);
+
+  if (slug) {
+    cy.get('#tag-slug').click().type(`${slug}`);
+  }
+
+  if (description) {
+    cy.get('#tag-description').click().type(`${description}`);
+  }
+
+  cy.get('body').then($body => {
+    if ($body.find('#parent').length !== 0) {
+      cy.get('#parent').select(parent.toString());
+    }
+  });
+
+  cy.get('#submit').click();
 };

--- a/tests/cypress/integration/create-term.test.js
+++ b/tests/cypress/integration/create-term.test.js
@@ -44,4 +44,57 @@ describe('Command: createTerm', () => {
       'A term with the name provided already exists in this taxonomy'
     );
   });
+
+  it('Should create categories with options', () => {
+    const parentCategory = {
+      name: 'Parent category',
+      description: 'Parent description',
+      slug: 'parent-slug',
+    };
+
+    cy.createTerm(parentCategory.name, 'category', {
+      description: parentCategory.description,
+      slug: parentCategory.slug,
+    });
+
+    // Assertions for parent category
+    cy.get('.notice').should('contain', 'Category added');
+
+    cy.get('#the-list .row-title')
+      .contains(parentCategory.name)
+      .then($parentLink => {
+        // Assertions of parent category
+        const $parentRow = $parentLink.parents('tr');
+
+        cy.wrap($parentRow)
+          .get('.description')
+          .should('contain', parentCategory.description);
+
+        cy.wrap($parentRow).get('.slug').should('contain', parentCategory.slug);
+
+        const parentId = $parentRow.find('input[name="delete_tags[]"]').val();
+
+        cy.createTerm('Child by parent id', 'category', { parent: parentId });
+        cy.wait(100);
+        cy.get('#the-list .row-title')
+          .contains('Child by parent id')
+          .then($child => {
+            cy.wrap($child.parents('tr'))
+              .get('.name .parent')
+              .should('contain', parentId.toString());
+          });
+
+        cy.createTerm('Child by parent name', 'category', {
+          parent: parentCategory.name,
+        });
+        cy.wait(100);
+        cy.get('#the-list .row-title')
+          .contains('Child by parent name')
+          .then($child => {
+            cy.wrap($child.parents('tr'))
+              .get('.name .parent')
+              .should('contain', parentId.toString());
+          });
+      });
+  });
 });


### PR DESCRIPTION
### Description of the Change

This PR adds new param to the `createTerm` command.

The third param is now an object with fields: `{parent, slug, description}`

I think we could use this approach for other commands to be flexible in terms of expandability and keep backwards compatibility.
### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @
