### PR TITLE
Fix login: wait for the page to load completely

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -17,7 +17,7 @@
  * ```
  */
 export const login = (username = 'admin', password = 'password'): void => {
-  cy.visit('wp-login.php');
+  cy.visit('/wp-admin/');
   cy.get('body').then($body => {
     if ($body.find('#wpwrap').length == 0) {
       cy.get('input#user_login').clear();

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -18,6 +18,11 @@
  */
 export const login = (username = 'admin', password = 'password'): void => {
   cy.visit('wp-login.php');
-  cy.get('input#user_login').click().clear().type(username);
-  cy.get('input#user_pass').click().clear().type(`${password}{enter}`);
+  cy.get('body').then($body => {
+    if ($body.find('#wpwrap').length == 0) {
+      cy.get('input#user_login').clear();
+      cy.get('input#user_login').click().type(username);
+      cy.get('input#user_pass').type(`${password}{enter}`);
+    }
+  });
 };


### PR DESCRIPTION
### Description of the Change

Changed login command: it will wait for the complete page to load before start typing (approach from 10up/simple-podcasting)

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

<!-- Enter any applicable Issues here. Example: -->
Closes #11 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

