### PR TITLE
createTerm to return term data

### DIFF
--- a/tests/cypress/integration/create-term.test.js
+++ b/tests/cypress/integration/create-term.test.js
@@ -97,4 +97,13 @@ describe('Command: createTerm', () => {
           });
       });
   });
+
+  it('Should retrieve term data from the command', () => {
+    const termName = 'Retrieval Category';
+    const expectedSlug = 'retrieval-category';
+    cy.createTerm(termName).then(term => {
+      assert(term.term_id > 0, 'Term ID should be greater than 0');
+      assert(term.slug === expectedSlug, 'Should have correct term slug');
+    });
+  });
 });

--- a/tests/cypress/integration/create-term.test.js
+++ b/tests/cypress/integration/create-term.test.js
@@ -102,6 +102,7 @@ describe('Command: createTerm', () => {
     const termName = 'Retrieval Category';
     const expectedSlug = 'retrieval-category';
     cy.createTerm(termName).then(term => {
+      assert(term.name === termName, 'Term name is the same');
       assert(term.term_id > 0, 'Term ID should be greater than 0');
       assert(term.slug === expectedSlug, 'Should have correct term slug');
     });


### PR DESCRIPTION
### Description of the Change
This PR allows to use data from created term:

```javascript
cy.createTerm('Category name').then(term => {
  console.log( term.term_id );
  console.log( term.slug );
});
```
### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @
