### PR TITLE
Added WP minimum env And Fixed createPost issues in WP<5.8

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,6 +18,7 @@ jobs:
         core:
           - { name: 'WP latest', version: 'latest' }
           - { name: 'WP trunk', version: 'WordPress/WordPress#master' }
+          - { name: 'WP minimum', version: 'WordPress/WordPress#5.2' }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -83,16 +83,8 @@ export const createPost = ({
 
     cy.get('.editor-post-publish-button').click();
 
-    cy.get('body').then($body => {
-      if ($body.find('.components-snackbar').length > 0) {
-        cy.get('.components-snackbar').should('be.visible');
-      } else {
-        // WP 5.2
-        cy.get('.components-notice.is-success').should(
-          'contain.text',
-          'published'
-        );
-      }
-    });
+    cy.get('.components-snackbar, .components-notice.is-success').should(
+      'be.visible'
+    );
   }
 };

--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -62,12 +62,16 @@ export const createPost = ({
   cy.get('body').then($body => {
     if ($body.find(welcomeGuide).length > 0) {
       cy.get(welcomeGuide).click();
+      // WP 5.2
+    } else if ($body.find('.nux-dot-tip__disable').length > 0) {
+      cy.get('.nux-dot-tip__disable').click();
     }
   });
 
   // Fill out data.
   cy.get(titleInput).clear().type(title);
-  cy.get(contentInput).type(content);
+  cy.get(contentInput).click();
+  cy.get('.block-editor-rich-text__editable').type(content);
 
   // Save/Publish Post.
   if (status === 'draft') {
@@ -79,6 +83,16 @@ export const createPost = ({
 
     cy.get('.editor-post-publish-button').click();
 
-    cy.get('.components-snackbar').should('be.visible');
+    cy.get('body').then($body => {
+      if ($body.find('.components-snackbar').length > 0) {
+        cy.get('.components-snackbar').should('be.visible');
+      } else {
+        // WP 5.2
+        cy.get('.components-notice.is-success').should(
+          'contain.text',
+          'published'
+        );
+      }
+    });
   }
 };

--- a/tests/cypress/integration/create-post.test.js
+++ b/tests/cypress/integration/create-post.test.js
@@ -2,8 +2,15 @@ describe('Command: createPost', () => {
   before(()=>{
     cy.login();
     cy.deactivatePlugin('classic-editor');
+    
+    // Ignore WP 5.2 Synchronous XHR error.
+    Cypress.on('uncaught:exception', (err, runnable) => {
+      if (err.message.includes("Failed to execute 'send' on 'XMLHttpRequest': Failed to load 'http://localhost:8889/wp-admin/admin-ajax.php': Synchronous XHR in page dismissal") ){
+        return false;
+      }
+    });
   });
-  
+
   beforeEach(() => {
     cy.login();
   });
@@ -15,7 +22,7 @@ describe('Command: createPost', () => {
       content: 'Test Content',
     });
 
-    cy.visit('/wp-admin/edit.php?orderby=date&order=desc');
+    cy.visit('/wp-admin/edit.php?orderby=date&order=desc');   
     cy.get('#the-list td.title a.row-title').first().should('have.text', title);
   });
 

--- a/tests/cypress/integration/create-post.test.js
+++ b/tests/cypress/integration/create-post.test.js
@@ -1,4 +1,9 @@
 describe('Command: createPost', () => {
+  before(()=>{
+    cy.login();
+    cy.deactivatePlugin('classic-editor');
+  });
+  
   beforeEach(() => {
     cy.login();
   });

--- a/tests/cypress/integration/set-permalink-structure.test.js
+++ b/tests/cypress/integration/set-permalink-structure.test.js
@@ -14,7 +14,7 @@ describe('Command: setPermalinkStructure', () => {
   structures.forEach(structure => {
     it(`Should be able to set predefined ${structure.name} permalinks`, () => {
       cy.setPermalinkStructure(structure.value);
-      cy.get('.notice-success').should(
+      cy.get('.notice-success, .notice.updated').should(
         'contain',
         'Permalink structure updated.'
       );
@@ -28,7 +28,7 @@ describe('Command: setPermalinkStructure', () => {
   it('Should be able to set custom permalinks', () => {
     const structure = '/custom/%second%/';
     cy.setPermalinkStructure(structure);
-    cy.get('.notice-success').should('contain', 'Permalink structure updated.');
+    cy.get('.notice-success, .notice.updated').should('contain', 'Permalink structure updated.');
     cy.get('.form-table.permalink-structure :checked').should(
       'have.value',
       'custom'
@@ -38,7 +38,7 @@ describe('Command: setPermalinkStructure', () => {
 
   it('Should receive error if no tag added', ()=>{
 	cy.setPermalinkStructure('no-tag');	
-	cy.get('.notice-error').should('contain', 'A structure tag is required when using custom permalinks.');
+	cy.get('.notice-error, .notice.error').should('contain', 'A structure tag is required when using custom permalinks.');
   });
 
   after(() => {


### PR DESCRIPTION
### Description of the Change
This PR adds WP Minimum env(WP 5.2) in GH actions and fixes below failed commands and tests in 5.2 env.
- `createPost`
- `setPermalinkStructure`

Closes #33 

Tests are still failing for the below commands in WP minimum env and I have created the GH issues as below:
- `createTerm` - #35
- `openDocumentSettingsPanel` & `openDocumentSettingsSidebar` - #36


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->
Added - WP minimum(5.2) env in GH actions to test with.
Changed - Made `createPost` and `setPermalinkStructure` compatible with WP minimum(5.2) env.
### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh 