### PR TITLE
Fix/35 `createTerm` tests made compatible with WP minimum env (5.2).

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,6 +18,7 @@ jobs:
         core:
           - { name: 'WP latest', version: 'latest' }
           - { name: 'WP trunk', version: 'WordPress/WordPress#master' }
+          - { name: 'WP minimum', version: 'WordPress/WordPress#5.2' }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 tests/cypress/screenshots
 tests/cypress/videos
 
+# wp-env files
+.wp-env.override.json
+
 # Logs
 logs
 *.log
@@ -110,6 +113,9 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+
+# PhpStorm
+.idea/
 
 # yarn v2
 .yarn/cache

--- a/tests/cypress/integration/create-term.test.js
+++ b/tests/cypress/integration/create-term.test.js
@@ -8,21 +8,34 @@ describe('Command: createTerm', () => {
   it('Should be able to Create a category', () => {
     const termName = 'My category';
     cy.createTerm(termName);
-    cy.get('.notice').should('contain', 'Category added');
+    cy.get('body').then($body => {
+      if ( $body.find('.notice').is(':visible') ) {
+        cy.get('.notice').should('contain', 'Category added');
+      }
+    });
     cy.get('.row-title').first().should('have.text', termName);
+
   });
 
   it('Should be able to Create a tag', () => {
     const termName = 'My tag';
     cy.createTerm(termName, 'post_tag');
-    cy.get('.notice').should('contain', 'Tag added');
+    cy.get('body').then($body => {
+      if ( $body.find('.notice').is(':visible') ) {
+        cy.get('.notice').should('contain', 'Tag added');
+      }
+    });
     cy.get('.row-title').first().should('have.text', termName);
   });
 
   it('Duplicate category should not be created', () => {
     const termName = 'My category';
     cy.createTerm(termName);
-    cy.get('.notice').should('contain', 'Category added');
+    cy.get('body').then($body => {
+      if ( $body.find('.notice').is(':visible') ) {
+        cy.get('.notice').should('contain', 'Category added');
+      }
+    });
     cy.get('.row-title').first().should('have.text', termName);
 
     cy.createTerm(termName);
@@ -35,7 +48,11 @@ describe('Command: createTerm', () => {
   it('Duplicate tag should not be created', () => {
     const termName = 'My tag';
     cy.createTerm(termName, 'post_tag');
-    cy.get('.notice').should('contain', 'Tag added');
+    cy.get('body').then($body => {
+      if ( $body.find('.notice').is(':visible') ) {
+        cy.get('.notice').should('contain', 'Tag added');
+      }
+    });
     cy.get('.row-title').first().should('have.text', termName);
 
     cy.createTerm(termName, 'post_tag');
@@ -58,7 +75,11 @@ describe('Command: createTerm', () => {
     });
 
     // Assertions for parent category
-    cy.get('.notice').should('contain', 'Category added');
+    cy.get('body').then($body => {
+      if ( $body.find('.notice').is(':visible') ) {
+        cy.get('.notice').should('contain', 'Category added');
+      }
+    });
 
     cy.get('#the-list .row-title')
       .contains(parentCategory.name)


### PR DESCRIPTION
### Description of the Change

Fixes the [fails](https://github.com/10up/cypress-wp-utils/runs/5748152338?check_suite_focus=true) for `createTerm` tests on WP Min.

<!-- Enter any applicable Issues here. Example: -->
Closes #35.

### Verification Process

Test `createTerm` against WordPress core 5.2 or check if `createTerm` (`create-term.test.js`) is passing in the Github Actions for WP Minimum. Please note other tests may still fail.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Changed - Updated `createTerm` tests to support WP Minimum `5.2`.

### Credits

Props @faisal-alvi @iamdharmesh 
