### PR TITLE
Fix createTerm tests

### DIFF
--- a/tests/cypress/integration/create-term.test.js
+++ b/tests/cypress/integration/create-term.test.js
@@ -1,3 +1,5 @@
+const { randomName } = require('../support/functions');
+
 describe('Command: createTerm', () => {
   beforeEach(() => {
     cy.login();
@@ -6,37 +8,36 @@ describe('Command: createTerm', () => {
   });
 
   it('Should be able to Create a category', () => {
-    const termName = 'My category';
+    const termName = 'Category ' + randomName();
     cy.createTerm(termName);
     cy.get('body').then($body => {
-      if ( $body.find('.notice').is(':visible') ) {
+      if ($body.find('.notice').is(':visible')) {
         cy.get('.notice').should('contain', 'Category added');
       }
     });
-    cy.get('.row-title').first().should('have.text', termName);
-
+    cy.get(`.row-title:contains("${termName}")`).should('exist');
   });
 
   it('Should be able to Create a tag', () => {
-    const termName = 'My tag';
+    const termName = 'Tag ' + randomName();
     cy.createTerm(termName, 'post_tag');
     cy.get('body').then($body => {
-      if ( $body.find('.notice').is(':visible') ) {
+      if ($body.find('.notice').is(':visible')) {
         cy.get('.notice').should('contain', 'Tag added');
       }
     });
-    cy.get('.row-title').first().should('have.text', termName);
+    cy.get(`.row-title:contains("${termName}")`).should('exist');
   });
 
   it('Duplicate category should not be created', () => {
-    const termName = 'My category';
+    const termName = 'Category ' + randomName();
     cy.createTerm(termName);
     cy.get('body').then($body => {
-      if ( $body.find('.notice').is(':visible') ) {
+      if ($body.find('.notice').is(':visible')) {
         cy.get('.notice').should('contain', 'Category added');
       }
     });
-    cy.get('.row-title').first().should('have.text', termName);
+    cy.get(`.row-title:contains("${termName}")`).should('exist');
 
     cy.createTerm(termName);
     cy.get('.error').should(
@@ -46,14 +47,14 @@ describe('Command: createTerm', () => {
   });
 
   it('Duplicate tag should not be created', () => {
-    const termName = 'My tag';
+    const termName = 'Tag ' + randomName();
     cy.createTerm(termName, 'post_tag');
     cy.get('body').then($body => {
-      if ( $body.find('.notice').is(':visible') ) {
+      if ($body.find('.notice').is(':visible')) {
         cy.get('.notice').should('contain', 'Tag added');
       }
     });
-    cy.get('.row-title').first().should('have.text', termName);
+    cy.get(`.row-title:contains("${termName}")`).should('exist');
 
     cy.createTerm(termName, 'post_tag');
     cy.get('.error').should(
@@ -64,8 +65,8 @@ describe('Command: createTerm', () => {
 
   it('Should create categories with options', () => {
     const parentCategory = {
-      name: 'Parent category',
-      description: 'Parent description',
+      name: 'Parent ' + randomName(),
+      description: 'Description ' + randomName(),
       slug: 'parent-slug',
     };
 
@@ -76,14 +77,13 @@ describe('Command: createTerm', () => {
 
     // Assertions for parent category
     cy.get('body').then($body => {
-      if ( $body.find('.notice').is(':visible') ) {
+      if ($body.find('.notice').is(':visible')) {
         cy.get('.notice').should('contain', 'Category added');
       }
     });
 
-    cy.get('#the-list .row-title')
-      .contains(parentCategory.name)
-      .then($parentLink => {
+    cy.get(`.row-title:contains("${parentCategory.name}")`).then(
+      $parentLink => {
         // Assertions of parent category
         const $parentRow = $parentLink.parents('tr');
 
@@ -95,33 +95,31 @@ describe('Command: createTerm', () => {
 
         const parentId = $parentRow.find('input[name="delete_tags[]"]').val();
 
-        cy.createTerm('Child by parent id', 'category', { parent: parentId });
-        cy.wait(100);
-        cy.get('#the-list .row-title')
-          .contains('Child by parent id')
-          .then($child => {
-            cy.wrap($child.parents('tr'))
-              .get('.name .parent')
-              .should('contain', parentId.toString());
-          });
+        const childById = 'Child ' + randomName();
+        cy.createTerm(childById, 'category', { parent: parentId });
+        cy.get(`.row-title:contains("${childById}")`).then($child => {
+          cy.wrap($child.parents('tr'))
+            .get('.name .parent')
+            .should('contain', parentId.toString());
+        });
 
-        cy.createTerm('Child by parent name', 'category', {
+        const childByName = 'Child ' + randomName();
+        cy.createTerm(childByName, 'category', {
           parent: parentCategory.name,
         });
-        cy.wait(100);
-        cy.get('#the-list .row-title')
-          .contains('Child by parent name')
-          .then($child => {
-            cy.wrap($child.parents('tr'))
-              .get('.name .parent')
-              .should('contain', parentId.toString());
-          });
-      });
+        cy.get(`.row-title:contains("${childByName}")`).then($child => {
+          cy.wrap($child.parents('tr'))
+            .get('.name .parent')
+            .should('contain', parentId.toString());
+        });
+      }
+    );
   });
 
   it('Should retrieve term data from the command', () => {
-    const termName = 'Retrieval Category';
-    const expectedSlug = 'retrieval-category';
+    const randomSuffix = randomName();
+    const termName = 'Category ' + randomSuffix;
+    const expectedSlug = 'category-' + randomSuffix;
     cy.createTerm(termName).then(term => {
       assert(term.name === termName, 'Term name is the same');
       assert(term.term_id > 0, 'Term ID should be greater than 0');

--- a/tests/cypress/support/functions.js
+++ b/tests/cypress/support/functions.js
@@ -1,0 +1,1 @@
+export const randomName = () => Math.random().toString(16).substring(7);


### PR DESCRIPTION
### Description of the Change

This PR adds improvements and fixes failed createTerm:
- Using random names for categories and tags
- Using async expectations instead of `cy.wait()`

Closes #44

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->