### PR TITLE
Single login for all tests

### DIFF
--- a/tests/cypress/integration/close-welcome-guide.test.js
+++ b/tests/cypress/integration/close-welcome-guide.test.js
@@ -26,12 +26,6 @@ describe('Command: closeWelcomeGuide', () => {
     });
   });
 
-  beforeEach(() => {
-    Cypress.Cookies.defaults({
-      preserve: /^wordpress.*?/,
-    });
-  });
-
   it('Should be able to Close Welcome Guide', () => {
     const welcomeGuideWindow = '.edit-post-welcome-guide';
 

--- a/tests/cypress/integration/close-welcome-guide.test.js
+++ b/tests/cypress/integration/close-welcome-guide.test.js
@@ -1,8 +1,6 @@
 describe('Command: closeWelcomeGuide', () => {
   before(() => {
-    Cypress.Cookies.defaults({
-      preserve: /^wordpress.*?/,
-    });
+    cy.login();
 
     // Disable Classic Editor if it's enabled
     cy.visit('/wp-admin/options-writing.php');

--- a/tests/cypress/integration/close-welcome-guide.test.js
+++ b/tests/cypress/integration/close-welcome-guide.test.js
@@ -1,6 +1,8 @@
 describe('Command: closeWelcomeGuide', () => {
   before(() => {
-    cy.login();
+    Cypress.Cookies.defaults({
+      preserve: /^wordpress.*?/,
+    });
 
     // Disable Classic Editor if it's enabled
     cy.visit('/wp-admin/options-writing.php');
@@ -27,7 +29,9 @@ describe('Command: closeWelcomeGuide', () => {
   });
 
   beforeEach(() => {
-    cy.login();
+    Cypress.Cookies.defaults({
+      preserve: /^wordpress.*?/,
+    });
   });
 
   it('Should be able to Close Welcome Guide', () => {

--- a/tests/cypress/integration/create-post.test.js
+++ b/tests/cypress/integration/create-post.test.js
@@ -1,6 +1,9 @@
 describe('Command: createPost', () => {
-  before(()=>{
-    cy.login();
+  before(() => {
+    Cypress.Cookies.defaults({
+      preserve: /^wordpress.*?/,
+    });
+
     cy.deactivatePlugin('classic-editor');
     
     // Ignore WP 5.2 Synchronous XHR error.
@@ -12,7 +15,9 @@ describe('Command: createPost', () => {
   });
 
   beforeEach(() => {
-    cy.login();
+    Cypress.Cookies.defaults({
+      preserve: /^wordpress.*?/,
+    });
   });
 
   it('Should be able to create Post', () => {

--- a/tests/cypress/integration/create-post.test.js
+++ b/tests/cypress/integration/create-post.test.js
@@ -12,12 +12,6 @@ describe('Command: createPost', () => {
     });
   });
 
-  beforeEach(() => {
-    Cypress.Cookies.defaults({
-      preserve: /^wordpress.*?/,
-    });
-  });
-
   it('Should be able to create Post', () => {
     const title = 'Test Post';
     cy.createPost({

--- a/tests/cypress/integration/create-post.test.js
+++ b/tests/cypress/integration/create-post.test.js
@@ -1,8 +1,6 @@
 describe('Command: createPost', () => {
   before(() => {
-    Cypress.Cookies.defaults({
-      preserve: /^wordpress.*?/,
-    });
+    cy.login();
 
     cy.deactivatePlugin('classic-editor');
     

--- a/tests/cypress/integration/create-term.test.js
+++ b/tests/cypress/integration/create-term.test.js
@@ -4,10 +4,6 @@ describe('Command: createTerm', () => {
   });
 
   beforeEach(() => {
-    Cypress.Cookies.defaults({
-      preserve: /^wordpress.*?/,
-    });
-
     cy.deleteAllTerms();
     cy.deleteAllTerms('post_tag');
   });

--- a/tests/cypress/integration/create-term.test.js
+++ b/tests/cypress/integration/create-term.test.js
@@ -1,4 +1,8 @@
 describe('Command: createTerm', () => {
+  before(() => {
+    cy.login();
+  });
+
   beforeEach(() => {
     Cypress.Cookies.defaults({
       preserve: /^wordpress.*?/,

--- a/tests/cypress/integration/create-term.test.js
+++ b/tests/cypress/integration/create-term.test.js
@@ -1,6 +1,9 @@
 describe('Command: createTerm', () => {
   beforeEach(() => {
-    cy.login();
+    Cypress.Cookies.defaults({
+      preserve: /^wordpress.*?/,
+    });
+
     cy.deleteAllTerms();
     cy.deleteAllTerms('post_tag');
   });

--- a/tests/cypress/integration/delete-all-terms.test.js
+++ b/tests/cypress/integration/delete-all-terms.test.js
@@ -1,6 +1,8 @@
 describe('Command: deleteAllTerms', () => {
   beforeEach(() => {
-    cy.login();
+    Cypress.Cookies.defaults({
+      preserve: /^wordpress.*?/,
+    });
   });
 
   after(() => {

--- a/tests/cypress/integration/delete-all-terms.test.js
+++ b/tests/cypress/integration/delete-all-terms.test.js
@@ -3,12 +3,6 @@ describe('Command: deleteAllTerms', () => {
     cy.login();
   });
 
-  beforeEach(() => {
-    Cypress.Cookies.defaults({
-      preserve: /^wordpress.*?/,
-    });
-  });
-
   after(() => {
     // Restore default 20 items per page
     cy.visit(`/wp-admin/edit-tags.php?taxonomy=category`);

--- a/tests/cypress/integration/delete-all-terms.test.js
+++ b/tests/cypress/integration/delete-all-terms.test.js
@@ -1,4 +1,8 @@
 describe('Command: deleteAllTerms', () => {
+  before(() => {
+    cy.login();
+  });
+
   beforeEach(() => {
     Cypress.Cookies.defaults({
       preserve: /^wordpress.*?/,

--- a/tests/cypress/integration/login.test.js
+++ b/tests/cypress/integration/login.test.js
@@ -1,4 +1,8 @@
 describe('Command: login', () => {
+  before(() => {
+    cy.logout();
+  });
+
   it('Login admin by default', () => {
     cy.login();
     cy.get('h1').should('contain', 'Dashboard');

--- a/tests/cypress/integration/logout.test.js
+++ b/tests/cypress/integration/logout.test.js
@@ -10,4 +10,8 @@ describe('Command: logout', () => {
     cy.visit(`/`);
     cy.logout();
   });
+
+  after(() => {
+    cy.login();
+  });
 });

--- a/tests/cypress/integration/open-document-settings.test.js
+++ b/tests/cypress/integration/open-document-settings.test.js
@@ -1,6 +1,8 @@
 describe('Commands: openDocumentSettings*', () => {
   before(() => {
-    cy.login();
+    Cypress.Cookies.defaults({
+      preserve: /^wordpress.*?/,
+    });
 
     // Disable Classic Editor if it's enabled
     cy.visit('/wp-admin/options-writing.php');
@@ -16,7 +18,9 @@ describe('Commands: openDocumentSettings*', () => {
   });
 
   beforeEach(() => {
-    cy.login();
+    Cypress.Cookies.defaults({
+      preserve: /^wordpress.*?/,
+    });
   });
 
   it("Should be able to open (don't close) Status Panel on a new post", () => {

--- a/tests/cypress/integration/open-document-settings.test.js
+++ b/tests/cypress/integration/open-document-settings.test.js
@@ -1,8 +1,6 @@
 describe('Commands: openDocumentSettings*', () => {
   before(() => {
-    Cypress.Cookies.defaults({
-      preserve: /^wordpress.*?/,
-    });
+    cy.login();
 
     // Disable Classic Editor if it's enabled
     cy.visit('/wp-admin/options-writing.php');

--- a/tests/cypress/integration/open-document-settings.test.js
+++ b/tests/cypress/integration/open-document-settings.test.js
@@ -26,12 +26,6 @@ describe('Commands: openDocumentSettings*', () => {
     });
   });
 
-  beforeEach(() => {
-    Cypress.Cookies.defaults({
-      preserve: /^wordpress.*?/,
-    });
-  });
-
   it("Should be able to open (don't close) Status Panel on a new post", () => {
     cy.visit(`/wp-admin/post-new.php`);
     cy.closeWelcomeGuide();

--- a/tests/cypress/integration/plugins.test.js
+++ b/tests/cypress/integration/plugins.test.js
@@ -3,12 +3,6 @@ describe('Plugins commands', () => {
     cy.login();
   });
 
-  beforeEach(() => {
-    Cypress.Cookies.defaults({
-      preserve: /^wordpress.*?/,
-    });
-  });
-
   it('Test plugins commands', () => {
     cy.activateAllPlugins();
     cy.visit('/wp-admin/plugins.php');

--- a/tests/cypress/integration/plugins.test.js
+++ b/tests/cypress/integration/plugins.test.js
@@ -1,4 +1,8 @@
 describe('Plugins commands', () => {
+  before(() => {
+    cy.login();
+  });
+
   beforeEach(() => {
     Cypress.Cookies.defaults({
       preserve: /^wordpress.*?/,

--- a/tests/cypress/integration/plugins.test.js
+++ b/tests/cypress/integration/plugins.test.js
@@ -1,6 +1,8 @@
 describe('Plugins commands', () => {
   beforeEach(() => {
-    cy.login();
+    Cypress.Cookies.defaults({
+      preserve: /^wordpress.*?/,
+    });
   });
 
   it('Test plugins commands', () => {

--- a/tests/cypress/integration/set-permalink-structure.test.js
+++ b/tests/cypress/integration/set-permalink-structure.test.js
@@ -3,12 +3,6 @@ describe('Command: setPermalinkStructure', () => {
     cy.login();
   });
 
-  beforeEach(() => {
-    Cypress.Cookies.defaults({
-      preserve: /^wordpress.*?/,
-    });
-  });
-
   const structures = [
     { name: 'Plain', value: '' },
     { name: 'Day and name', value: '/%year%/%monthnum%/%day%/%postname%/' },

--- a/tests/cypress/integration/set-permalink-structure.test.js
+++ b/tests/cypress/integration/set-permalink-structure.test.js
@@ -1,6 +1,8 @@
 describe('Command: setPermalinkStructure', () => {
   beforeEach(() => {
-    cy.login();
+    Cypress.Cookies.defaults({
+      preserve: /^wordpress.*?/,
+    });
   });
 
   const structures = [

--- a/tests/cypress/integration/set-permalink-structure.test.js
+++ b/tests/cypress/integration/set-permalink-structure.test.js
@@ -1,4 +1,8 @@
 describe('Command: setPermalinkStructure', () => {
+  before(() => {
+    cy.login();
+  });
+
   beforeEach(() => {
     Cypress.Cookies.defaults({
       preserve: /^wordpress.*?/,

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -22,5 +22,6 @@ import '../../../lib/index';
 describe('Init', () => {
   it('Log in', () => {
     cy.login();
+	cy.get('h1').should('contain', 'Dashboard');
   });
 });

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -18,3 +18,9 @@ import '../../../lib/index';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+describe('Init', () => {
+  it('Log in', () => {
+    cy.login();
+  });
+});

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -18,10 +18,3 @@ import '../../../lib/index';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
-
-describe('Init', () => {
-  it('Log in', () => {
-    cy.login();
-	cy.get('h1').should('contain', 'Dashboard');
-  });
-});

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -18,3 +18,8 @@ import '../../../lib/index';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+beforeEach(() => {
+  Cypress.Cookies.defaults({
+    preserve: /^wordpress.*?/,
+  });
+});


### PR DESCRIPTION
### Description of the Change

This PR brings new optimized workflow for user authentication:
1. Admin is being logged in single time `before` test every suite (was logged in before each test in the suite)
2. Auth cookie is being preserved from cleanup `beforeEach` test

Closes #31 

### Alternate Design 1

We have tested more aggressive auth cookie preserving with single log in inside a "Meta" suite in `support/index.js` but this approach fails when running Cypress in cli mode (read more https://github.com/10up/cypress-wp-utils/pull/46#issuecomment-1085869034)

### Alternate Design 2

Cypress since 8.2 has experimental cy.session() command. It can provide the same functionality for our login command:

```typescript
export const login = (username = 'admin', password = 'password'): void => {
  cy.session([username, password], () => {
    cy.visit('/wp-admin/');
    cy.get('body').then($body => {
      if ($body.find('#wpwrap').length == 0) {
        cy.get('input#user_login').clear();
        cy.get('input#user_login').click().type(username);
        cy.get('input#user_pass').type(`${password}{enter}`);
      }
    });
  });
};
```
The workflow is as follows:
1. At the first call of login command, the login process happens as usual, the session (cookies, localStorage) has been saved in the storage identified by `[username, password]` key.
2. At the next login command call, if Cypress has existing session saved, it will be set up instead of performing full process.

#### Pros

- Updating our login command will work out of the box. Tester will still require to add `cy.login()` to `beforeEach`, but the login process will only happen during the first call.
- Will work faster to switch between two or more different user sessions because only requires single login for each user. With the current PR solution, the whole login workflow should happen on every user switch.

#### Cons

- This is experimental command and it requires `"experimentalSessionSupport": true` setting in the config

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->