### PR TITLE
Skip parent selection if it's not specified

### DIFF
--- a/src/commands/create-term.ts
+++ b/src/commands/create-term.ts
@@ -72,11 +72,13 @@ export const createTerm = (
     cy.get('#tag-description').click().type(`${description}`);
   }
 
-  cy.get('body').then($body => {
-    if ($body.find('#parent').length !== 0) {
-      cy.get('#parent').select(parent.toString());
-    }
-  });
+  if (parent !== -1) {
+    cy.get('body').then($body => {
+      if ($body.find('#parent').length !== 0) {
+        cy.get('#parent').select(parent.toString());
+      }
+    });
+  }
 
   cy.get('#submit').click();
 


### PR DESCRIPTION
### Description of the Change
This PR changes createTerm command workflow: it will skip setting the parent dropdown if the value of parent is default `-1` which means "create top-level term"

Closes #50

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @dinhtungdu @cadic 
