### PR TITLE
Add Hooks to createPost and createTerm

### DIFF
--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -5,7 +5,8 @@
  *          `postType` - Post type,
  *          `title` - Post Title,
  *          `content` - Post Content,
- *          `status` - Post Status
+ *          `status` - Post Status,
+ *          `beforeSave` - Callback
  *        }
  *
  * @example
@@ -36,17 +37,30 @@
  *   content: 'Page Content'
  * })
  * ```
+ *
+ * @example
+ * Perform custom actions before saving the post
+ * ```
+ * cy.createPost({
+ *   title: 'Post Title',
+ *   beforeSave: () => {
+ *     // Change additional metaboxes.
+ *   }
+ * })
+ * ```
  */
 export const createPost = ({
   postType = 'post',
   title = 'Test Post',
   content = 'Test content',
   status = 'publish',
+  beforeSave,
 }: {
   title: string;
   postType?: string;
   content?: string;
   status?: string;
+  beforeSave?: CallableFunction;
 }): void => {
   cy.visit(`/wp-admin/post-new.php?post_type=${postType}`);
 
@@ -72,6 +86,10 @@ export const createPost = ({
   cy.get(titleInput).clear().type(title);
   cy.get(contentInput).click();
   cy.get('.block-editor-rich-text__editable').type(content);
+
+  if ('undefined' !== typeof beforeSave) {
+    beforeSave();
+  }
 
   // Save/Publish Post.
   if (status === 'draft') {

--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -6,7 +6,7 @@
  *          `title` - Post Title,
  *          `content` - Post Content,
  *          `status` - Post Status,
- *          `beforeSave` - Callback
+ *          `beforeSave` - Callable function hook
  *        }
  *
  * @example

--- a/src/commands/create-term.ts
+++ b/src/commands/create-term.ts
@@ -7,7 +7,7 @@
  *          slug - Taxonomy slug
  *          parent - Parent taxonomy (ID or name)
  *          description - Taxonomy description
- * 			beforeSave - Callback
+ * 			beforeSave - Callable function hook
  *        }
  *
  * @example

--- a/src/commands/create-term.ts
+++ b/src/commands/create-term.ts
@@ -7,6 +7,7 @@
  *          slug - Taxonomy slug
  *          parent - Parent taxonomy (ID or name)
  *          description - Taxonomy description
+ * 			beforeSave - Callback
  *        }
  *
  * @example
@@ -52,7 +53,13 @@ export const createTerm = (
     slug = '',
     parent = -1,
     description = '',
-  }: { slug?: string; parent?: number | string; description?: string } = {}
+    beforeSave,
+  }: {
+    slug?: string;
+    parent?: number | string;
+    description?: string;
+    beforeSave?: CallableFunction;
+  } = {}
 ): void => {
   cy.visit(`/wp-admin/edit-tags.php?taxonomy=${taxonomy}`);
 
@@ -78,6 +85,10 @@ export const createTerm = (
         cy.get('#parent').select(parent.toString());
       }
     });
+  }
+
+  if ('undefined' !== typeof beforeSave) {
+    beforeSave();
   }
 
   cy.get('#submit').click();

--- a/tests/cypress/integration/create-post.test.js
+++ b/tests/cypress/integration/create-post.test.js
@@ -1,3 +1,5 @@
+const { randomName } = require('../support/functions');
+
 describe('Command: createPost', () => {
   before(() => {
     cy.login();
@@ -72,5 +74,30 @@ describe('Command: createPost', () => {
         cy.wrap($row).find('a.row-title').should('have.text', title);
         cy.wrap($row).find('span.post-state').should('have.text', 'Draft');
       });
+  });
+
+  it('Should be able to use beforeSave hook', () => {
+    const postTitle = 'Post ' + randomName();
+    const postContent = 'Content ' + randomName();
+    cy.createPost({
+      title: postTitle,
+      content: postContent,
+      beforeSave: () => {
+        cy.openDocumentSettingsPanel('Status & visibility');
+        cy.get('label')
+          .contains('Stick to the top of the blog')
+          .click()
+          .parent()
+          .find('input[type="checkbox"]')
+          .should('be.checked');
+      },
+    });
+
+    cy.visit('/wp-admin/edit.php?post_type=post');
+    cy.get('td.title')
+      .contains(postTitle)
+      .parent()
+      .find('.post-state')
+      .should('contain.text', 'Sticky');
   });
 });

--- a/tests/cypress/integration/create-term.test.js
+++ b/tests/cypress/integration/create-term.test.js
@@ -129,4 +129,22 @@ describe('Command: createTerm', () => {
       assert(term.slug === expectedSlug, 'Should have correct term slug');
     });
   });
+
+  it('Should be able to use beforeSave hook', () => {
+    const termName = 'Category ' + randomName();
+    const termSlug = 'cat-' + randomName();
+    const overrideSlug = 'cat-' + randomName();
+    cy.createTerm(termName, 'category', {
+      slug: termSlug,
+      beforeSave: () => {
+        cy.get('#tag-slug').click().type('{selectAll}').type(overrideSlug);
+      },
+    });
+
+    cy.get('td.name')
+      .contains(termName)
+      .parents('tr')
+      .find('.slug')
+      .should('contain.text', overrideSlug);
+  });
 });


### PR DESCRIPTION
### Description of the Change

In some cases we need to perform additional setup or assertions in the middle of other commands. For example:
- Add some specific settings to the post being created
- Set fields in metaboxes for custom post type
- Update details of a new term before saving it

This PR introducing hooks feature. `createPost` and `createTerm` commands now have optional `beforeSave` parameter where you can add custom code to execute:

```javascript
cy.createPost({
  title: 'Title',
  content: 'Content',

  // Make sticky post
  beforeSave: () => {
    cy.openDocumentSettingsPanel("Status & visibility");
    cy.get("label")
      .contains("Stick to the top of the blog")
      .click()
      .parent()
      .find('input[type="checkbox"]')
      .should("be.checked");
  },
});
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Added - `beforeSave` hook in `createPost` and `createTerm` commands

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic 