### PR TITLE
Skip cypress test if no sensitive files changed

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,6 +22,7 @@ jobs:
         uses: tj-actions/changed-files@v18.7
         with:
           files: |
+            .github/workflows/cypress.yml
             src/*
             tests/*
             cypress-wp-utils.php

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -35,7 +35,7 @@ jobs:
   cypress:
     name: ${{ matrix.core.name }}
     needs: changed-files
-    if: needs.changed-files.outputs.status == 'true'
+    if: ${{ needs.changed-files.outputs.status == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -44,6 +44,8 @@ jobs:
           - { name: 'WP trunk', version: 'WordPress/WordPress#master' }
           - { name: 'WP minimum', version: 'WordPress/WordPress#5.2' }
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Install dependencies
         run: npm install
       - name: Build

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,7 +22,7 @@ jobs:
         uses: tj-actions/changed-files@v18.7
         with:
           files: |
-            .github/worflows/cypress.yml
+            .github/workflows/cypress.yml
             src/*
             tests/*
             cypress-wp-utils.php

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,7 +22,6 @@ jobs:
         uses: tj-actions/changed-files@v18.7
         with:
           files: |
-            .github/*
             src/*
             tests/*
             cypress-wp-utils.php

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,15 +10,11 @@ on:
     - cron: '36 7 * * 6'
 
 jobs:
-  cypress:
-    name: ${{ matrix.core.name }}
+  changed-files:
+    name: Changed Files
+    outputs:
+      status: ${{ steps.changed-files.outputs.any_changed }}
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        core:
-          - { name: 'WP latest', version: 'latest' }
-          - { name: 'WP trunk', version: 'WordPress/WordPress#master' }
-          - { name: 'WP minimum', version: 'WordPress/WordPress#5.2' }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -36,6 +32,18 @@ jobs:
       - name: List Modified Files
         run: echo "${{ steps.changed-files.outputs.all_changed_files }}" | xargs ls -lh
 
+  cypress:
+    name: ${{ matrix.core.name }}
+    needs: changed-files
+    if: needs.changed-files.outputs.status == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        core:
+          - { name: 'WP latest', version: 'latest' }
+          - { name: 'WP trunk', version: 'WordPress/WordPress#master' }
+          - { name: 'WP minimum', version: 'WordPress/WordPress#5.2' }
+    steps:
       - name: Install dependencies
         run: npm install
       - name: Build

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,6 +22,7 @@ jobs:
         uses: tj-actions/changed-files@v18.7
         with:
           files: |
+            .github/*
             src/*
             tests/*
             cypress-wp-utils.php

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,7 +22,7 @@ jobs:
         uses: tj-actions/changed-files@v18.7
         with:
           files: |
-            .github/*
+            .github/worflows/cypress.yml
             src/*
             tests/*
             cypress-wp-utils.php

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,13 +17,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - id: changed-files
-        uses: sk-/pr-changed-files
+        uses: tj-actions/changed-files@v18.7
+        with:
+          files: |
+            .github/*
+            src/*
+            tests/*
+            cypress-wp-utils.php
+            .wp-env.json
+            package.json
+            package-lock.json
       - name: List Modified Files
-        run: echo "${{ steps.changed-files.outputs.files }}" | xargs ls -lh
+        run: echo "${{ steps.changed-files.outputs.all_changed_files }}" | xargs ls -lh
 
   cypress:
     name: ${{ matrix.core.name }}
     runs-on: ubuntu-latest
+    if: jobs.changed-files.steps.changed-files.outputs.any_changed == 'true'
     strategy:
       matrix:
         core:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,6 +10,17 @@ on:
     - cron: '36 7 * * 6'
 
 jobs:
+  changed-files:
+    name: Changed Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: changed-files
+        uses: sk-/pr-changed-files
+      - name: List Modified Files
+        run: echo "${{ steps.changed-files.outputs.files }}" | xargs ls -lh
+
   cypress:
     name: ${{ matrix.core.name }}
     runs-on: ubuntu-latest

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -29,8 +29,6 @@ jobs:
             .wp-env.json
             package.json
             package-lock.json
-      - name: List Modified Files
-        run: echo "${{ steps.changed-files.outputs.all_changed_files }}" | xargs ls -lh
 
   cypress:
     name: ${{ matrix.core.name }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,9 +10,15 @@ on:
     - cron: '36 7 * * 6'
 
 jobs:
-  changed-files:
-    name: Changed Files
+  cypress:
+    name: ${{ matrix.core.name }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        core:
+          - { name: 'WP latest', version: 'latest' }
+          - { name: 'WP trunk', version: 'WordPress/WordPress#master' }
+          - { name: 'WP minimum', version: 'WordPress/WordPress#5.2' }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -30,19 +36,6 @@ jobs:
       - name: List Modified Files
         run: echo "${{ steps.changed-files.outputs.all_changed_files }}" | xargs ls -lh
 
-  cypress:
-    name: ${{ matrix.core.name }}
-    runs-on: ubuntu-latest
-    if: jobs.changed-files.steps.changed-files.outputs.any_changed == 'true'
-    strategy:
-      matrix:
-        core:
-          - { name: 'WP latest', version: 'latest' }
-          - { name: 'WP trunk', version: 'WordPress/WordPress#master' }
-          - { name: 'WP minimum', version: 'WordPress/WordPress#5.2' }
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Install dependencies
         run: npm install
       - name: Build

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,7 +22,6 @@ jobs:
         uses: tj-actions/changed-files@v18.7
         with:
           files: |
-            .github/workflows/cypress.yml
             src/*
             tests/*
             cypress-wp-utils.php

--- a/cypress-wp-utils.php
+++ b/cypress-wp-utils.php
@@ -6,3 +6,4 @@
  */
 
 add_action( 'init', '__return_false' );
+// Test change.

--- a/cypress-wp-utils.php
+++ b/cypress-wp-utils.php
@@ -6,4 +6,3 @@
  */
 
 add_action( 'init', '__return_false' );
-// Test change.


### PR DESCRIPTION
### Description of the Change

Running Cypress tests against the PR which doesn't contain any significant changes is redundant.

This PR adds new pre-requirement job before cypress test which checks if files has been changes. The following Cypress E2E job will run only if the PR has changes in what really needs testing:
- src/*
- tests/*
- Cypress workflow config file
- WordPress-related files (wp-env config and example plugin)
- Node config files

If no of this list is changed (f.e. this is just a readme update), the heavy E2E job will be skipped.

🌱 🌏 🌱 🌎 🌱 🌍 🌱

### Possible Drawbacks

The current solution works in a sensitive-list approach: if no of the sensitive files has changed, we can skip tests. Means we **only** run test if **any** of sensitive files changed. It may cause troubles if a contributor add new sensitive files outside of the known list without updating `cypress.yml`

### Alternate Designs

We can perform a non-relevant-list approach: adding "safe-to-skip" list of files.

### Verification Process

Check Actions history, I've performed multiple tests with commits which include sensitive files and other commits which doesn't.

- Needs-testing commit: https://github.com/10up/cypress-wp-utils/pull/57/commits/71370e62ddffcca76480d6165207c4c4aa091062, Action: [run full test](https://github.com/10up/cypress-wp-utils/actions/runs/2188064996)
- Safe-to-skip commit: https://github.com/10up/cypress-wp-utils/pull/57/commits/389e0f4724f90ba0b2b0676a217e7b6a1ff099b0, Action: [skip full test](https://github.com/10up/cypress-wp-utils/actions/runs/2188123368)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.