### PR TITLE
Insert Block command

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,9 @@
 {
-  "plugins": [".", "WordPress/classic-editor"],
+  "plugins": [
+    ".",
+    "WordPress/classic-editor",
+    "https://github.com/10up/retro-winamp-block/releases/download/1.0.1/retro-winamp-block.zip"
+  ],
   "env": {
     "tests": {
       "mappings": {

--- a/run-all-cores.sh
+++ b/run-all-cores.sh
@@ -2,12 +2,12 @@
 
 VERSIONS="5.2 5.3 5.4 5.5 5.6 5.7 5.8 latest master"
 
-SPEC=""
+SPEC="-- --quiet"
 
 while getopts s: flag
 do
     case "${flag}" in
-        s) SPEC="-- --spec $OPTARG";;
+        s) SPEC="-- --quiet --spec $OPTARG";;
     esac
 done
 
@@ -16,9 +16,9 @@ for VERSION in $VERSIONS; do
 	echo $VERSION
 	echo "**********************************************"
 	./tests/bin/set-core-version.js $VERSION
-	npm run env:start
-	npm run env run tests-cli "core update-db"
-	npm run env clean
+	npm run env:start > /dev/null
+	npm run env run tests-cli "core update-db" > /dev/null
+	npm run env clean > /dev/null
 	npm run cypress:run $SPEC
-	npm run env:stop
+	npm run env:stop > /dev/null
 done

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -1,0 +1,44 @@
+/**
+ * Inserts Block
+ *
+ * The resulting block id is yielded
+ *
+ * @param type - Block type
+ *
+ * @example
+ * ```
+ * cy.insertBlock('core/heading').then(id => {
+ *   cy.get(`#${id}`).click().type('A quick brown fox');
+ * });
+ * ```
+ */
+export const insertBlock = (type: string): void => {
+  // replace first occurence only to keep sub-blocks work
+  let slug = type.replace('/', '-');
+
+  // Remove core blocks prefix
+  slug = slug.replace(/^core-/, '');
+
+  // Escape "/" to allow selectors for sub-blocks
+  slug = slug.replace(/\//, '\\/');
+
+  // Open blocks panel
+  cy.get('.edit-post-header-toolbar__inserter-toggle').click();
+
+  // Insert the block
+  cy.get(`.editor-block-list-item-${slug}`).click();
+
+  // Close blocks panel
+  cy.get('.edit-post-header-toolbar__inserter-toggle.is-pressed').click();
+
+  // Remove tailing suffix of sub-blocks
+  type = type.replace(/^(.*?)\/(.*?)\/[^/]+$/, '$1/$2');
+
+  // Get last block of the current type
+  cy.get(`.wp-block[data-type="${type}"]`)
+    .last()
+    .then(block => {
+      const id = block.prop('id');
+      cy.wrap(id);
+    });
+};

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -1,9 +1,12 @@
+import { fail } from 'assert';
+
 /**
  * Inserts Block
  *
  * The resulting block id is yielded
  *
  * @param type - Block type
+ * @param name - Block name (used to search)
  *
  * @example
  * ```
@@ -12,33 +15,78 @@
  * });
  * ```
  */
-export const insertBlock = (type: string): void => {
+export const insertBlock = (type: string, name?: string): void => {
   // replace first occurence only to keep sub-blocks work
   let slug = type.replace('/', '-');
 
   // Remove core blocks prefix
   slug = slug.replace(/^core-/, '');
 
+  // old gutenberg selector
+  const slugAlt = slug.replace(/\//, '-');
+
   // Escape "/" to allow selectors for sub-blocks
   slug = slug.replace(/\//, '\\/');
 
+  let search;
+  if (name) {
+    search = name;
+  } else {
+    search = type.split('/').pop();
+    if ('undefined' === typeof search) {
+      search = type;
+    }
+  }
+
   // Open blocks panel
-  cy.get('.edit-post-header-toolbar__inserter-toggle').click();
+  cy.get(
+    '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
+  ).click();
+
+  cy.get('.block-editor-inserter__search').click().type(search);
 
   // Insert the block
-  cy.get(`.editor-block-list-item-${slug}`).click();
+  cy.get('body').then($body => {
+    if ($body.find(`.editor-block-list-item-${slug}`).length > 0) {
+      cy.get(`.editor-block-list-item-${slug}`).click();
+    } else if ($body.find(`.editor-block-list-item-${slugAlt}`).length > 0) {
+      cy.get(`.editor-block-list-item-${slugAlt}`).click();
+    } else {
+      fail(`Could not find '${type}' block`);
+    }
+  });
 
   // Close blocks panel
-  cy.get('.edit-post-header-toolbar__inserter-toggle.is-pressed').click();
+  cy.get('body').then($body => {
+    if (
+      $body.find('.edit-post-header-toolbar__inserter-toggle.is-pressed')
+        .length > 0
+    ) {
+      cy.get('.edit-post-header-toolbar__inserter-toggle.is-pressed').click();
+    }
+  });
 
   // Remove tailing suffix of sub-blocks
-  type = type.replace(/^(.*?)\/(.*?)\/[^/]+$/, '$1/$2');
+  const blockType = type.replace(/^(.*?)\/(.*?)\/[^/]+$/, '$1/$2');
+
+  const blockTypeAlt = type.replace('/', '-');
 
   // Get last block of the current type
-  cy.get(`.wp-block[data-type="${type}"]`)
-    .last()
-    .then(block => {
-      const id = block.prop('id');
-      cy.wrap(id);
-    });
+  cy.get('body').then($body => {
+    if ($body.find(`.wp-block[data-type="${blockType}"]`).length > 0) {
+      cy.get(`.wp-block[data-type="${blockType}"]`)
+        .last()
+        .then(block => {
+          const id = block.prop('id');
+          cy.wrap(id);
+        });
+    } else if ($body.find(`.wp-block[data-type="${blockTypeAlt}"]`)) {
+      cy.get(`.wp-block[data-type="${blockTypeAlt}"]`)
+        .last()
+        .then(block => {
+          const id = block.prop('id');
+          cy.wrap(id);
+        });
+    }
+  });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 /// <reference types="cypress" />
 
 // Import commands.
+import { insertBlock } from './commands/insert-block';
 import { closeWelcomeGuide } from './commands/close-welcome-guide';
 import { wpCliEval } from './commands/wp-cli-eval';
 import { wpCli } from './commands/wp-cli';
@@ -21,6 +22,7 @@ import { createPost } from './commands/create-post';
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {
+      insertBlock: typeof insertBlock;
       closeWelcomeGuide: typeof closeWelcomeGuide;
       wpCliEval: typeof wpCliEval;
       wpCli: typeof wpCli;
@@ -41,6 +43,7 @@ declare global {
 }
 
 // Register commands
+Cypress.Commands.add('insertBlock', insertBlock);
 Cypress.Commands.add('closeWelcomeGuide', closeWelcomeGuide);
 Cypress.Commands.add('wpCliEval', wpCliEval);
 Cypress.Commands.add('wpCli', wpCli);

--- a/tests/cypress/integration/insert-block.test.js
+++ b/tests/cypress/integration/insert-block.test.js
@@ -101,21 +101,38 @@ describe('Command: insertBlock', () => {
           },
         });
       } else {
-        expect(true, 'Skipping test, Next Page block does not exist');
+        assert(true, 'Skipping test, Next Page block does not exist');
       }
     });
   });
 
   it('Should be able to insert custom block', () => {
-    cy.createPost({
-      beforeSave: () => {
-        cy.insertBlock('tenup/winamp-block').then(id => {
-          cy.get(`#${id}`)
-            .should('contain.text', 'Add Audio')
-            .should('have.attr', 'data-type')
-            .and('eq', 'tenup/winamp-block');
+    cy.visit('/wp-admin/post-new.php');
+    cy.closeWelcomeGuide();
+    const titleInput = 'h1.editor-post-title__input, #post-title-0';
+    cy.get(titleInput).should('exist');
+    cy.get(
+      '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
+    ).click();
+
+    // Detect if the block exist (added in 5.9)
+    cy.get('.block-editor-inserter__search').click().type('winamp');
+    cy.get('body').then($body => {
+      const slug = 'tenup\\/winamp-block';
+      if ($body.find(`.editor-block-list-item-${slug}`).length > 0) {
+        cy.createPost({
+          beforeSave: () => {
+            cy.insertBlock('tenup/winamp-block').then(id => {
+              cy.get(`#${id}`)
+                .should('contain.text', 'Add Audio')
+                .should('have.attr', 'data-type')
+                .and('eq', 'tenup/winamp-block');
+            });
+          },
         });
-      },
+      } else {
+        assert(true, 'Skipping test, Winamp block does not exist');
+      }
     });
   });
 });

--- a/tests/cypress/integration/insert-block.test.js
+++ b/tests/cypress/integration/insert-block.test.js
@@ -118,7 +118,7 @@ describe('Command: insertBlock', () => {
     // Detect if the block exist (added in 5.9)
     cy.get('.block-editor-inserter__search').click().type('winamp');
     cy.get('body').then($body => {
-      const slug = 'tenup\\/winamp-block';
+      const slug = 'tenup-winamp-block';
       if ($body.find(`.editor-block-list-item-${slug}`).length > 0) {
         cy.createPost({
           beforeSave: () => {

--- a/tests/cypress/integration/insert-block.test.js
+++ b/tests/cypress/integration/insert-block.test.js
@@ -105,4 +105,17 @@ describe('Command: insertBlock', () => {
       }
     });
   });
+
+  it('Should be able to insert custom block', () => {
+    cy.createPost({
+      beforeSave: () => {
+        cy.insertBlock('tenup/winamp-block').then(id => {
+          cy.get(`#${id}`)
+            .should('contain.text', 'Add Audio')
+            .should('have.attr', 'data-type')
+            .and('eq', 'tenup/winamp-block');
+        });
+      },
+    });
+  });
 });

--- a/tests/cypress/integration/insert-block.test.js
+++ b/tests/cypress/integration/insert-block.test.js
@@ -1,0 +1,98 @@
+const { randomName } = require('../support/functions');
+
+describe('Command: insertBlock', () => {
+  before(() => {
+    cy.login();
+    cy.deactivatePlugin('classic-editor');
+  });
+
+  it('Should be able to Insert first paragraph on page', () => {
+    const paragraph = 'Paragraph ' + randomName();
+    cy.createPost({
+      beforeSave: () => {
+        // remove the existing paragraph
+        cy.get('.edit-post-header-toolbar__list-view-toggle').click();
+        cy.get('.block-editor-list-view-tree .block-editor-list-view-leaf')
+          .first()
+          .find('.components-dropdown-menu__toggle')
+          .click();
+        cy.get('.components-popover .components-menu-item__button')
+          .contains('Remove Paragraph')
+          .click();
+        cy.get(
+          '.edit-post-header-toolbar__list-view-toggle.is-pressed'
+        ).click();
+
+        cy.insertBlock('core/paragraph').then(id => {
+          cy.get(`#${id}`).click().type(paragraph);
+        });
+      },
+    });
+
+    cy.get('.block-editor-writing-flow')
+      .should('not.contain.text', 'Test content')
+      .should('contain.text', paragraph);
+  });
+
+  it('Should be able to Insert Heading', () => {
+    const heading = 'Heading ' + randomName();
+    cy.createPost({
+      beforeSave: () => {
+        cy.insertBlock('core/heading').then(id => {
+          cy.get(`#${id}`).click();
+          cy.get(
+            '.components-popover .components-button[aria-label="Change heading level"]'
+          ).click();
+          cy.get('.components-button[aria-label="Heading 3"]').click();
+          cy.get(`#${id}`).click().type(heading);
+        });
+      },
+    });
+
+    cy.get('.block-editor-writing-flow h3.wp-block').should(
+      'contain.text',
+      heading
+    );
+  });
+
+  it('Should be able to insert Pullquote', () => {
+    const quote = 'Quote ' + randomName();
+    const cite = 'Cite ' + randomName();
+    cy.createPost({
+      beforeSave: () => {
+        cy.insertBlock('core/pullquote').then(id => {
+          cy.get(`#${id} [aria-label="Pullquote text"]`).click().type(quote);
+          cy.get(`#${id} [aria-label="Pullquote citation text"]`)
+            .click()
+            .type(cite);
+        });
+      },
+    });
+
+    cy.get('.wp-block-pullquote')
+      .should('contain.text', quote)
+      .should('contain.text', cite);
+  });
+
+  it('Should be able to insert an Embed sub-block', () => {
+    cy.createPost({
+      beforeSave: () => {
+        cy.insertBlock('core/embed/twitter');
+      },
+    });
+
+    cy.get('.wp-block-embed').should('contain.text', 'Twitter');
+  });
+
+  it('Should be able to insert Post-nav sub-block', () => {
+    cy.createPost({
+      beforeSave: () => {
+        cy.insertBlock('core/post-navigation-link/post-next');
+      },
+    });
+
+    cy.get('.wp-block-post-navigation-link > a')
+      .should('have.attr', 'aria-label')
+      .and('eq', 'Next post');
+  });
+});

--- a/tests/cypress/integration/insert-block.test.js
+++ b/tests/cypress/integration/insert-block.test.js
@@ -78,25 +78,31 @@ describe('Command: insertBlock', () => {
   });
 
   it('Should be able to insert Post-nav sub-block', () => {
-    cy.createPost({
-      beforeSave: () => {
-        cy.get('body').then($body => {
-          // Only run test on newer WordPress with "Post Next" block
-          if (
-            $body.find(
-              '[class*="editor-block-list-item-post-navigation-link/post-next"]'
-            ).length > 0
-          ) {
+    cy.visit('/wp-admin/post-new.php');
+    cy.closeWelcomeGuide();
+    const titleInput = 'h1.editor-post-title__input, #post-title-0';
+    cy.get(titleInput).should('exist');
+    cy.get(
+      '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
+    ).click();
+
+    // Detect if the block exist (added in 5.9)
+    cy.get('.block-editor-inserter__search').click().type('Next post');
+    cy.get('body').then($body => {
+      const slug = 'post-navigation-link\\/post-next';
+      if ($body.find(`.editor-block-list-item-${slug}`).length > 0) {
+        cy.createPost({
+          beforeSave: () => {
             cy.insertBlock('core/post-navigation-link/post-next', 'Next');
 
             cy.get('.wp-block-post-navigation-link > a')
               .should('have.attr', 'aria-label')
               .and('eq', 'Next post');
-          } else {
-            expect(true, "Skipping the test, block hasn't been added yet");
-          }
+          },
         });
-      },
+      } else {
+        expect(true, 'Skipping test, Next Page block does not exist');
+      }
     });
   });
 });


### PR DESCRIPTION
### Description of the Change

Adds `insertBlock` command. Yields the block element ID:

```javascript
cy.insertBlock('core/heading').then(id => {
  cy.get(`#${id}`).click().type(heading);
});
```

Tests include custom block from [10up/retro-winamp-block](https://github.com/10up/retro-winamp-block), it doesn't support WordPress 5.2, so this test is optional.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Added - `insertBlock` command

### Credits

Props @cadic
