### PR TITLE
Separate build job with cache

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -32,17 +32,22 @@ jobs:
 
   build:
     name: Build
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.status == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Cache
+      - name: Cache Node
         uses: actions/cache@v3
         with:
-          path: |
-            ~/lib
-            ~/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ hashFiles('package-lock.json') }}
+      - name: Cache Build
+        uses: actions/cache@v3
+        with:
+          path: lib
+          key: ${{ runner.os }}-build-${{ hashFiles('src/**') }}
       - name: Install dependencies
         run: npm install
       - name: Build
@@ -50,8 +55,7 @@ jobs:
 
   cypress:
     name: ${{ matrix.core.name }}
-    needs: changed-files
-    if: ${{ needs.changed-files.outputs.status == 'true' }}
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -62,13 +66,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Cache
+      - name: Cache Node
         uses: actions/cache@v3
         with:
-          path: |
-            ~/lib
-            ~/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ hashFiles('package-lock.json') }}
+      - name: Cache Build
+        uses: actions/cache@v3
+        with:
+          path: lib
+          key: ${{ runner.os }}-build-${{ hashFiles('src/**') }}
       - name: Set the core version
         run: ./tests/bin/set-core-version.js ${{ matrix.core.version }}
       - name: Set up WP environment

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -41,7 +41,10 @@ jobs:
       - name: Cache Node
         uses: actions/cache@v3
         with:
-          path: node_modules
+          path: |
+            node_modules
+            ~/.cache
+            ~/.npm
           key: ${{ runner.os }}-build-${{ hashFiles('package-lock.json') }}
       - name: Cache Build
         uses: actions/cache@v3
@@ -55,7 +58,8 @@ jobs:
 
   cypress:
     name: ${{ matrix.core.name }}
-    needs: build
+    needs: [changed-files, build]
+    if: ${{ needs.changed-files.outputs.status == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -69,7 +73,10 @@ jobs:
       - name: Cache Node
         uses: actions/cache@v3
         with:
-          path: node_modules
+          path: |
+            node_modules
+            ~/.cache
+            ~/.npm
           key: ${{ runner.os }}-build-${{ hashFiles('package-lock.json') }}
       - name: Cache Build
         uses: actions/cache@v3

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -30,6 +30,24 @@ jobs:
             package.json
             package-lock.json
 
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/lib
+            ~/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+
   cypress:
     name: ${{ matrix.core.name }}
     needs: changed-files
@@ -44,11 +62,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install dependencies
-        run: npm install
-      - name: Build
-        run: npm run build
-        continue-on-error: true
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/lib
+            ~/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
       - name: Set the core version
         run: ./tests/bin/set-core-version.js ${{ matrix.core.version }}
       - name: Set up WP environment


### PR DESCRIPTION
### Description of the Change

This PR adds separate job for install node and build with cache.

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/288381/164223902-d07c21b1-99bc-461d-99d4-1106c60bb8b4.png">

- Node cache is identified by the hash of `package-lock.json` and includes Cypress binary from `~/.cache`.
- Build cache is identified by the hash of all files in `src`

A little more CPU energy to save!

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.