### PR TITLE
Command/39 `checkPostExists` from any CPT

### DIFF
--- a/src/commands/check-post-exists.ts
+++ b/src/commands/check-post-exists.ts
@@ -1,9 +1,26 @@
 /**
  * Check Post Exists
  *
+ * @param postData {
+ *          `title` - Post Title,
+ *          `postType` - Post type,
+ *        }
+ *
  * @example
+ * Check for the `post`, without spefifying second parameer.
  * ```
- * cy.checkPostExists()
+ * cy.checkPostExists({
+ *    title: 'Hello world!',
+ * })
+ * ```
+ *
+ * @example
+ * Check for the `page`.
+ * ```
+ * cy.checkPostExists({
+ *    title: 'Sample Page',
+ *    postType: 'page',
+ * })
  * ```
  */
 export const checkPostExists = ({

--- a/src/commands/check-post-exists.ts
+++ b/src/commands/check-post-exists.ts
@@ -40,5 +40,11 @@ export const checkPostExists = ({
   cy.get(searchInput).clear().type(title).get(searchSubmit).click();
 
   // See if the post is listed in the search result.
-  cy.get(postLabel).should('exist');
+  cy.get('body').then($body => {
+    if ($body.find(postLabel).length > 0) {
+      cy.wrap(true);
+    } else {
+      cy.wrap(false);
+    }
+  });
 };

--- a/src/commands/check-post-exists.ts
+++ b/src/commands/check-post-exists.ts
@@ -1,0 +1,27 @@
+/**
+ * Check Post Exists
+ *
+ * @example
+ * ```
+ * cy.checkPostExists()
+ * ```
+ */
+export const checkPostExists = ({
+  title,
+  postType = 'post',
+}: {
+  title: string;
+  postType?: string;
+}): void => {
+  cy.visit(`/wp-admin/edit.php?post_type=${postType}`);
+
+  const searchInput = '#post-search-input';
+  const searchSubmit = '#search-submit';
+  const postLabel = '[aria-label="Move “' + title + '” to the Trash"]';
+
+  // Search for the post title.
+  cy.get(searchInput).clear().type(title).get(searchSubmit).click();
+
+  // See if the post is listed in the search result.
+  cy.get(postLabel).should('exist');
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 /// <reference types="cypress" />
 
 // Import commands.
+import { checkPostExists } from './commands/check-post-exists';
 import { closeWelcomeGuide } from './commands/close-welcome-guide';
 import { wpCliEval } from './commands/wp-cli-eval';
 import { wpCli } from './commands/wp-cli';
@@ -21,6 +22,7 @@ import { createPost } from './commands/create-post';
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {
+      checkPostExists: typeof checkPostExists;
       closeWelcomeGuide: typeof closeWelcomeGuide;
       wpCliEval: typeof wpCliEval;
       wpCli: typeof wpCli;
@@ -41,6 +43,7 @@ declare global {
 }
 
 // Register commands
+Cypress.Commands.add('checkPostExists', checkPostExists);
 Cypress.Commands.add('closeWelcomeGuide', closeWelcomeGuide);
 Cypress.Commands.add('wpCliEval', wpCliEval);
 Cypress.Commands.add('wpCli', wpCli);

--- a/tests/cypress/integration/check-post-exists.test.js
+++ b/tests/cypress/integration/check-post-exists.test.js
@@ -26,6 +26,7 @@ describe('Command: checkPostExists', () => {
 
   before(() => {
     cy.login();
+    cy.activatePlugin('classic-editor');
 
     // Create posts which expected to exist during tests
     tests.forEach(test => {

--- a/tests/cypress/integration/check-post-exists.test.js
+++ b/tests/cypress/integration/check-post-exists.test.js
@@ -6,6 +6,14 @@ describe('Command: checkPostExists', () => {
   it('Should be able to Check if Post Exists', () => {
     cy.checkPostExists({
       title: 'Hello world!',
+    }).then(exists => {
+      if (exists) {
+        console.log('The post exists!');
+        // The block patter exists!
+      } else {
+        console.log('The post does not exist!');
+        // The block pattern does not exist!
+      }
     });
   });
 
@@ -13,6 +21,14 @@ describe('Command: checkPostExists', () => {
     cy.checkPostExists({
       title: 'Sample Page',
       postType: 'page',
+    }).then(exists => {
+      if (exists) {
+        console.log('The page exists!');
+        // The block patter exists!
+      } else {
+        console.log('The page does not exist!');
+        // The block pattern does not exist!
+      }
     });
   });
 });

--- a/tests/cypress/integration/check-post-exists.test.js
+++ b/tests/cypress/integration/check-post-exists.test.js
@@ -26,12 +26,12 @@ describe('Command: checkPostExists', () => {
 
   before(() => {
     cy.login();
-    cy.activatePlugin('classic-editor');
+    cy.deactivatePlugin('classic-editor');
 
     // Create posts which expected to exist during tests
     tests.forEach(test => {
       if (test.expected) {
-        cy.classicCreatePost({
+        cy.createPost({
           postType: test.postType,
           title: test.postTitle,
         });

--- a/tests/cypress/integration/check-post-exists.test.js
+++ b/tests/cypress/integration/check-post-exists.test.js
@@ -40,7 +40,7 @@ describe('Command: checkPostExists', () => {
   });
 
   tests.forEach(test => {
-    const shouldIt = test.exists ? 'should' : 'should not';
+    const shouldIt = test.expected ? 'should' : 'should not';
     it(`${test.postTitle} ${shouldIt} exist`, () => {
       const args = {
         title: test.postTitle,

--- a/tests/cypress/integration/check-post-exists.test.js
+++ b/tests/cypress/integration/check-post-exists.test.js
@@ -1,0 +1,18 @@
+describe('Command: checkPostExists', () => {
+  before(() => {
+    cy.login();
+  });
+
+  it('Should be able to Check if Post Exists', () => {
+    cy.checkPostExists({
+      title: 'Hello world!',
+    });
+  });
+
+  it('Should be able to Check if Page Exists', () => {
+    cy.checkPostExists({
+      title: 'Sample Page',
+      postType: 'page',
+    });
+  });
+});

--- a/tests/cypress/integration/check-post-exists.test.js
+++ b/tests/cypress/integration/check-post-exists.test.js
@@ -28,6 +28,17 @@ describe('Command: checkPostExists', () => {
     cy.login();
     cy.deactivatePlugin('classic-editor');
 
+    // Ignore WP 5.2 Synchronous XHR error.
+    Cypress.on('uncaught:exception', (err, runnable) => {
+      if (
+        err.message.includes(
+          "Failed to execute 'send' on 'XMLHttpRequest': Failed to load 'http://localhost:8889/wp-admin/admin-ajax.php': Synchronous XHR in page dismissal"
+        )
+      ) {
+        return false;
+      }
+    });
+
     // Create posts which expected to exist during tests
     tests.forEach(test => {
       if (test.expected) {

--- a/tests/cypress/integration/check-post-exists.test.js
+++ b/tests/cypress/integration/check-post-exists.test.js
@@ -1,34 +1,57 @@
+const { randomName } = require('../support/functions');
+
 describe('Command: checkPostExists', () => {
+  const tests = [
+    {
+      postType: 'post',
+      postTitle: 'Post ' + randomName(),
+      expected: true,
+    },
+    {
+      postType: 'post',
+      postTitle: 'Post ' + randomName(),
+      expected: false,
+    },
+    {
+      postType: 'page',
+      postTitle: 'Page ' + randomName(),
+      expected: true,
+    },
+    {
+      postType: 'page',
+      postTitle: 'Post ' + randomName(),
+      expected: false,
+    },
+  ];
+
   before(() => {
     cy.login();
-  });
 
-  it('Should be able to Check if Post Exists', () => {
-    cy.checkPostExists({
-      title: 'Hello world!',
-    }).then(exists => {
-      if (exists) {
-        console.log('The post exists!');
-        // The block patter exists!
-      } else {
-        console.log('The post does not exist!');
-        // The block pattern does not exist!
+    // Create posts which expected to exist during tests
+    tests.forEach(test => {
+      if (test.expected) {
+        cy.classicCreatePost({
+          postType: test.postType,
+          title: test.postTitle,
+        });
       }
     });
   });
 
-  it('Should be able to Check if Page Exists', () => {
-    cy.checkPostExists({
-      title: 'Sample Page',
-      postType: 'page',
-    }).then(exists => {
-      if (exists) {
-        console.log('The page exists!');
-        // The block patter exists!
-      } else {
-        console.log('The page does not exist!');
-        // The block pattern does not exist!
+  tests.forEach(test => {
+    const shouldIt = test.exists ? 'should' : 'should not';
+    it(`${test.postTitle} ${shouldIt} exist`, () => {
+      const args = {
+        title: test.postTitle,
+      };
+
+      // make 'postType' argument optional to test default value
+      if ('post' !== test.postType) {
+        args.postType = test.postType;
       }
+      cy.checkPostExists(args).then(exists => {
+        assert(exists === test.expected, `Post ${shouldIt} exist`);
+      });
     });
   });
 });


### PR DESCRIPTION
### Description of the Change

Added a new command `checkPostExists` which checks whether a given post title exists in a specified post type or not.

It accepts the following parameters.
- `title`: Post Title.
- `postType`: Post type. Default to `post`.

Note: The command searches for the exact `title` on the site. It fails the test if the title string does not match.

<!-- Enter any applicable Issues here. Example: -->
Closes #39

### Verification Process

1. Build the project using `npm run build`.
2. Make sure the docker is running.
3. Run `npm run env:start`.
4. Run `npm run cypress:open`.
5. Run `check-post-exists.test.js`.
6. Try to change the post title(s) in the `/tests/cypress/integration/check-post-exists.test.js` file and see the test should fail.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Added - New Command `checkPostExists` to check if post exists.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @faisal-alvi 