### PR TITLE
Update notice selector for WP 6.1 in createTerm test

### DIFF
--- a/tests/cypress/integration/create-term.test.js
+++ b/tests/cypress/integration/create-term.test.js
@@ -43,7 +43,7 @@ describe('Command: createTerm', () => {
     cy.get(`.row-title:contains("${termName}")`).should('exist');
 
     cy.createTerm(termName);
-    cy.get('.error').should(
+    cy.get('.error, .notice-error').should(
       'contain',
       'A term with the name provided already exists with this parent'
     );
@@ -60,7 +60,7 @@ describe('Command: createTerm', () => {
     cy.get(`.row-title:contains("${termName}")`).should('exist');
 
     cy.createTerm(termName, 'post_tag');
-    cy.get('.error').should(
+    cy.get('.error, .notice-error').should(
       'contain',
       'A term with the name provided already exists in this taxonomy'
     );


### PR DESCRIPTION
### Description of the Change

In WordPress 6.1, an error message for terms has changed class from `error` to `notice notice-error`. To fix broken test we update the selector.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #72