### PR TITLE
security/71: bump minimum WordPress version from 5.2 to 5.7

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -67,7 +67,7 @@ jobs:
         core:
           - { name: 'WP latest', version: 'latest', number: '6.1' }
           - { name: 'WP trunk', version: 'WordPress/WordPress#master', number: '6.2' }
-          - { name: 'WP minimum', version: 'WordPress/WordPress#5.2', number: '5.2' }
+          - { name: 'WP minimum', version: 'WordPress/WordPress#5.7', number: '5.7' }
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Bump minimum WordPress version from 5.2 to 5.7 in GitHub workflows


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #71 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Security - Bump minimum WordPress version from 5.2 to 5.7 in GitHub workflows


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @Sidsector9 @vikrampm1 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
