### PR TITLE
Fix create term test

### DIFF
--- a/tests/cypress/e2e/create-term.test.js
+++ b/tests/cypress/e2e/create-term.test.js
@@ -13,33 +13,18 @@ describe('Command: createTerm', () => {
   it('Should be able to Create a category', () => {
     const termName = 'Category ' + randomName();
     cy.createTerm(termName);
-    cy.get('body').then($body => {
-      if ($body.find('.notice').is(':visible')) {
-        cy.get('.notice').should('contain', 'Category added');
-      }
-    });
     cy.get(`.row-title:contains("${termName}")`).should('exist');
   });
 
   it('Should be able to Create a tag', () => {
     const termName = 'Tag ' + randomName();
     cy.createTerm(termName, 'post_tag');
-    cy.get('body').then($body => {
-      if ($body.find('.notice').is(':visible')) {
-        cy.get('.notice').should('contain', 'Tag added');
-      }
-    });
     cy.get(`.row-title:contains("${termName}")`).should('exist');
   });
 
   it('Duplicate category should not be created', () => {
     const termName = 'Category ' + randomName();
     cy.createTerm(termName);
-    cy.get('body').then($body => {
-      if ($body.find('.notice').is(':visible')) {
-        cy.get('.notice').should('contain', 'Category added');
-      }
-    });
     cy.get(`.row-title:contains("${termName}")`).should('exist');
 
     cy.createTerm(termName);
@@ -52,11 +37,6 @@ describe('Command: createTerm', () => {
   it('Duplicate tag should not be created', () => {
     const termName = 'Tag ' + randomName();
     cy.createTerm(termName, 'post_tag');
-    cy.get('body').then($body => {
-      if ($body.find('.notice').is(':visible')) {
-        cy.get('.notice').should('contain', 'Tag added');
-      }
-    });
     cy.get(`.row-title:contains("${termName}")`).should('exist');
 
     cy.createTerm(termName, 'post_tag');
@@ -79,12 +59,6 @@ describe('Command: createTerm', () => {
     });
 
     // Assertions for parent category
-    cy.get('body').then($body => {
-      if ($body.find('.notice').is(':visible')) {
-        cy.get('.notice').should('contain', 'Category added');
-      }
-    });
-
     cy.get(`.row-title:contains("${parentCategory.name}")`).then(
       $parentLink => {
         // Assertions of parent category


### PR DESCRIPTION
### Description of the Change
Remove checking for the notice text when testing createTerm command, the notice selector vary from version to versin, does not exist in 5.7 at all and does not makes any sense in the test scenario since we are also checking that the term was added to terms table.

Closes #81 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - createTerm command tests

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
