### PR TITLE
Fix broken tests in WordPress 6.2

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,7 @@
   "plugins": [
     ".",
     "WordPress/classic-editor",
-    "https://github.com/10up/retro-winamp-block/releases/download/1.0.1/retro-winamp-block.zip"
+    "https://github.com/10up/retro-winamp-block/releases/download/1.2.0/retro-winamp-block.zip"
   ],
   "env": {
     "tests": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,7 @@
   "plugins": [
     ".",
     "WordPress/classic-editor",
-    "https://github.com/10up/retro-winamp-block/releases/download/1.2.0/retro-winamp-block.zip"
+    "https://github.com/10up/retro-winamp-block/releases/download/1.0.1/retro-winamp-block.zip"
   ],
   "env": {
     "tests": {

--- a/run-all-cores.sh
+++ b/run-all-cores.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSIONS="5.2 5.3 5.4 5.5 5.6 5.7 5.8 5.9 latest:6.0 master:6.1"
+VERSIONS="5.7 5.8 5.9 6.0 6.1 master:6.2"
 
 SPEC="-- --quiet"
 

--- a/src/commands/close-welcome-guide.ts
+++ b/src/commands/close-welcome-guide.ts
@@ -9,7 +9,7 @@
 export const closeWelcomeGuide = (): void => {
   const titleInput = 'h1.editor-post-title__input, #post-title-0';
   const closeButtonSelector =
-    'button[aria-label="Close dialog"], button[aria-label="Disable tips"]';
+    '.edit-post-welcome-guide .components-modal__header button';
 
   // Wait for edit page to load
   cy.get(titleInput).should('exist');

--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -66,21 +66,12 @@ export const createPost = ({
 
   const titleInput = 'h1.editor-post-title__input, #post-title-0';
   const contentInput = '.block-editor-default-block-appender__content';
-  const welcomeGuide =
-    '.edit-post-welcome-guide .components-modal__header button';
 
   // Make sure editor loaded properly.
   cy.get(titleInput).should('exist');
 
   // Close Welcome Guide.
-  cy.get('body').then($body => {
-    if ($body.find(welcomeGuide).length > 0) {
-      cy.get(welcomeGuide).click();
-      // WP 5.2
-    } else if ($body.find('.nux-dot-tip__disable').length > 0) {
-      cy.get('.nux-dot-tip__disable').click();
-    }
-  });
+  cy.closeWelcomeGuide();
 
   // Fill out data.
   cy.get(titleInput).clear().type(title);

--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -76,7 +76,7 @@ export const createPost = ({
   // Fill out data.
   cy.get(titleInput).clear().type(title);
   cy.get(contentInput).click();
-  cy.get('.block-editor-rich-text__editable').type(content);
+  cy.get('.block-editor-rich-text__editable').first().type(content);
 
   if ('undefined' !== typeof beforeSave) {
     beforeSave();

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -45,6 +45,8 @@ export const insertBlock = (type: string, name?: string): void => {
 
   cy.get('.block-editor-inserter__search').click().type(search);
 
+  cy.wait(300); // eslint-disable-line
+
   // Insert the block
   cy.get(`.editor-block-list-item-${slug}, .editor-block-list-item-${slugAlt}`)
     .first()

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -46,15 +46,10 @@ export const insertBlock = (type: string, name?: string): void => {
   cy.get('.block-editor-inserter__search').click().type(search);
 
   // Insert the block
-  cy.get('body').then($body => {
-    if ($body.find(`.editor-block-list-item-${slug}`).length > 0) {
-      cy.get(`.editor-block-list-item-${slug}`).click({ force: true });
-    } else if ($body.find(`.editor-block-list-item-${slugAlt}`).length > 0) {
-      cy.get(`.editor-block-list-item-${slugAlt}`).click({ force: true });
-    } else {
-      fail(`Could not find '${type}' block`);
-    }
-  });
+  cy.get(`.editor-block-list-item-${slug}, .editor-block-list-item-${slugAlt}`)
+    .first()
+    .should('be.visible')
+    .click();
 
   // Close blocks panel
   cy.get('body').then($body => {

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -43,12 +43,14 @@ export const insertBlock = (type: string, name?: string): void => {
     '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
   ).click();
 
-  cy.get('.block-editor-inserter__search').click().type(search);
+  cy.get('.block-editor-inserter__search')
+    .click()
+    .type(search)
+    .type('{enter}', { delay: 500 });
 
   // Insert the block
   cy.get(`.editor-block-list-item-${slug}, .editor-block-list-item-${slugAlt}`)
     .first()
-    .should('be.visible')
     .click();
 
   // Close blocks panel

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -43,14 +43,14 @@ export const insertBlock = (type: string, name?: string): void => {
     '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
   ).click();
 
-  cy.get('.block-editor-inserter__search').click().type(search);
+  cy.get('.block-editor-inserter__search').click().type(search).type('{enter}');
 
   // Insert the block
   cy.get('body').then($body => {
     if ($body.find(`.editor-block-list-item-${slug}`).length > 0) {
-      cy.get(`.editor-block-list-item-${slug}`).click();
+      cy.get(`.editor-block-list-item-${slug}`).should('be.visible').click();
     } else if ($body.find(`.editor-block-list-item-${slugAlt}`).length > 0) {
-      cy.get(`.editor-block-list-item-${slugAlt}`).click();
+      cy.get(`.editor-block-list-item-${slugAlt}`).should('be.visible').click();
     } else {
       fail(`Could not find '${type}' block`);
     }

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -45,8 +45,6 @@ export const insertBlock = (type: string, name?: string): void => {
 
   cy.get('.block-editor-inserter__search').click().type(search);
 
-  cy.wait(300); // eslint-disable-line
-
   // Insert the block
   cy.get(`.editor-block-list-item-${slug}, .editor-block-list-item-${slugAlt}`)
     .first()

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -43,14 +43,14 @@ export const insertBlock = (type: string, name?: string): void => {
     '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
   ).click();
 
-  cy.get('.block-editor-inserter__search').click().type(search).type('{enter}');
+  cy.get('.block-editor-inserter__search').click().type(search);
 
   // Insert the block
   cy.get('body').then($body => {
     if ($body.find(`.editor-block-list-item-${slug}`).length > 0) {
-      cy.get(`.editor-block-list-item-${slug}`).should('be.visible').click();
+      cy.get(`.editor-block-list-item-${slug}`).click({ force: true });
     } else if ($body.find(`.editor-block-list-item-${slugAlt}`).length > 0) {
-      cy.get(`.editor-block-list-item-${slugAlt}`).should('be.visible').click();
+      cy.get(`.editor-block-list-item-${slugAlt}`).click({ force: true });
     } else {
       fail(`Could not find '${type}' block`);
     }

--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -79,32 +79,21 @@ describe('Command: insertBlock', () => {
   });
 
   it('Should be able to insert custom block', () => {
-    cy.visit('/wp-admin/post-new.php');
-    cy.closeWelcomeGuide();
-    const titleInput = 'h1.editor-post-title__input, #post-title-0';
-    cy.get(titleInput).should('exist');
-    cy.get(
-      '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
-    ).click();
+    if (compare(Cypress.env('WORDPRESS_CORE').toString(), '5.9', '<')) {
+      // The block was added in WordPress 5.9, skipping the test.
+      assert(true, 'Skipping test, WinAmp block does not exist');
+      return;
+    }
 
-    // Detect if the block exist (added in 5.9)
-    cy.get('.block-editor-inserter__search').click().type('winamp');
-    cy.get('body').then($body => {
-      const slug = 'tenup-winamp-block';
-      if ($body.find(`.editor-block-list-item-${slug}`).length > 0) {
-        cy.createPost({
-          beforeSave: () => {
-            cy.insertBlock('tenup/winamp-block').then(id => {
-              cy.get(`#${id}`)
-                .should('contain.text', 'Add Audio')
-                .should('have.attr', 'data-type')
-                .and('eq', 'tenup/winamp-block');
-            });
-          },
-        });
-      } else {
-        assert(true, 'Skipping test, Winamp block does not exist');
-      }
+    cy.createPost({
+      beforeSave: () => {
+        cy.insertBlock('tenup/winamp-block', 'WinAmp');
+      },
     });
+
+    cy.get('.wp-block-tenup-winamp-block')
+      .should('contain.text', 'Add Audio')
+      .should('have.attr', 'data-type')
+      .and('eq', 'tenup/winamp-block');
   });
 });

--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -1,4 +1,5 @@
 const { randomName } = require('../support/functions');
+import { compare } from 'compare-versions';
 
 describe('Command: insertBlock', () => {
   before(() => {
@@ -78,6 +79,12 @@ describe('Command: insertBlock', () => {
   });
 
   it('Should be able to insert Post-nav sub-block', () => {
+    if (compare(Cypress.env('WORDPRESS_CORE').toString(), '5.9', '<')) {
+      // The block was added in WordPress 5.9, skipping the test.
+      assert(true, 'Skipping test, Next Page block does not exist');
+      return;
+    }
+
     cy.visit('/wp-admin/post-new.php');
     cy.closeWelcomeGuide();
     const titleInput = 'h1.editor-post-title__input, #post-title-0';
@@ -86,23 +93,14 @@ describe('Command: insertBlock', () => {
       '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
     ).click();
 
-    // Detect if the block exist (added in 5.9)
-    cy.get('.block-editor-inserter__search').click().type('Next post');
-    cy.get('body').then($body => {
-      const slug = 'post-navigation-link\\/post-next';
-      if ($body.find(`.editor-block-list-item-${slug}`).length > 0) {
-        cy.createPost({
-          beforeSave: () => {
-            cy.insertBlock('core/post-navigation-link/post-next', 'Next');
+    cy.createPost({
+      beforeSave: () => {
+        cy.insertBlock('core/post-navigation-link/post-next', 'Next');
 
-            cy.get('.wp-block-post-navigation-link > a')
-              .should('have.attr', 'aria-label')
-              .and('eq', 'Next post');
-          },
-        });
-      } else {
-        assert(true, 'Skipping test, Next Page block does not exist');
-      }
+        cy.get('.wp-block-post-navigation-link > a')
+          .should('have.attr', 'aria-label')
+          .and('eq', 'Next post');
+      },
     });
   });
 

--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -78,32 +78,6 @@ describe('Command: insertBlock', () => {
     cy.get('.wp-block-embed').should('contain.text', 'Twitter');
   });
 
-  it('Should be able to insert Post-nav sub-block', () => {
-    if (compare(Cypress.env('WORDPRESS_CORE').toString(), '5.9', '<')) {
-      // The block was added in WordPress 5.9, skipping the test.
-      assert(true, 'Skipping test, Next Page block does not exist');
-      return;
-    }
-
-    cy.visit('/wp-admin/post-new.php');
-    cy.closeWelcomeGuide();
-    const titleInput = 'h1.editor-post-title__input, #post-title-0';
-    cy.get(titleInput).should('exist');
-    cy.get(
-      '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
-    ).click();
-
-    cy.createPost({
-      beforeSave: () => {
-        cy.insertBlock('core/post-navigation-link/post-next', 'Next');
-
-        cy.get('.wp-block-post-navigation-link > a')
-          .should('have.attr', 'aria-label')
-          .and('eq', 'Next post');
-      },
-    });
-  });
-
   it('Should be able to insert custom block', () => {
     cy.visit('/wp-admin/post-new.php');
     cy.closeWelcomeGuide();

--- a/tests/cypress/e2e/open-document-settings.test.js
+++ b/tests/cypress/e2e/open-document-settings.test.js
@@ -129,7 +129,7 @@ describe('Commands: openDocumentSettings*', () => {
       cy.closeWelcomeGuide();
 
       cy.get('body').then($body => {
-        if ($body.find('.wp-block-post-content > .wp-block')) {
+        if ($body.find('.wp-block-post-content > .wp-block').length > 0) {
           cy.get('.wp-block-post-content > .wp-block').first().click();
         } else {
           // Fallback for WordPress 5.7

--- a/tests/cypress/e2e/open-document-settings.test.js
+++ b/tests/cypress/e2e/open-document-settings.test.js
@@ -129,7 +129,7 @@ describe('Commands: openDocumentSettings*', () => {
       cy.closeWelcomeGuide();
 
       cy.get('body').then($body => {
-        if ($body.find('.wp-block-post-content')) {
+        if ($body.find('.wp-block-post-content > .wp-block')) {
           cy.get('.wp-block-post-content > .wp-block').first().click();
         } else {
           // Fallback for WordPress 5.7

--- a/tests/cypress/e2e/open-document-settings.test.js
+++ b/tests/cypress/e2e/open-document-settings.test.js
@@ -128,7 +128,7 @@ describe('Commands: openDocumentSettings*', () => {
       cy.visit(`/wp-admin/post.php?post=${post.id}&action=edit`);
       cy.closeWelcomeGuide();
 
-      cy.get('.block-editor-block-list__layout > .wp-block').first().click();
+      cy.get('.wp-block-post-content > .wp-block').first().click();
       cy.openDocumentSettingsSidebar('Block');
 
       // Assertions:

--- a/tests/cypress/e2e/open-document-settings.test.js
+++ b/tests/cypress/e2e/open-document-settings.test.js
@@ -128,7 +128,17 @@ describe('Commands: openDocumentSettings*', () => {
       cy.visit(`/wp-admin/post.php?post=${post.id}&action=edit`);
       cy.closeWelcomeGuide();
 
-      cy.get('.wp-block-post-content > .wp-block').first().click();
+      cy.get('body').then($body => {
+        if ($body.find('.wp-block-post-content')) {
+          cy.get('.wp-block-post-content > .wp-block').first().click();
+        } else {
+          // Fallback for WordPress 5.7
+          cy.get('.block-editor-block-list__layout > .wp-block')
+            .first()
+            .click();
+        }
+      });
+
       cy.openDocumentSettingsSidebar('Block');
 
       // Assertions:


### PR DESCRIPTION
### Description of the Change

In the WordPress 6.2 RC there was a few changes to the selectors in the block editor, which we are updating in this PR to fix broken tests.

Closes #88

- Updates the `createPost` command: select the first occurence of the rich text container (WordPress 6.2 has multiple results for this selector)
- Updates the `insertBlock` command to wait for the blocks list to render after the search (fix "element is detached from the DOM" error in WP 6.2)
- Updated the `closeWelcomeGuide` command and added the shortcut to `createPost` command
- Removed unnecessary test for `insertBlock`
- Fixed failing `openDocumentSettingsPanel` test
- Added conditional test of WinAmp block based on the `WORDPRESS_CORE` env instead of DOM search.
- Updated the list of core versions in `run-all-cores.sh` script

### Changelog Entry
> Fixed - Broken tests in WordPress 6.2

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
