### PR TITLE
Ensure that omitting the title or content fields doesn’t cause an error in createPost

### DIFF
--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -68,15 +68,20 @@ export const createPost = ({
   const contentInput = '.block-editor-default-block-appender__content';
 
   // Make sure editor loaded properly.
-  cy.get(titleInput).should('exist');
+  cy.get(contentInput).should('exist');
 
   // Close Welcome Guide.
   cy.closeWelcomeGuide();
 
   // Fill out data.
-  cy.get(titleInput).clear().type(title);
-  cy.get(contentInput).click();
-  cy.get('.block-editor-rich-text__editable').first().type(content);
+  if (title.length > 0) {
+    cy.get(titleInput).clear().type(title);
+  }
+
+  if (content.length > 0) {
+    cy.get(contentInput).click();
+    cy.get('.block-editor-rich-text__editable').first().type(content);
+  }
 
   if ('undefined' !== typeof beforeSave) {
     beforeSave();

--- a/tests/cypress/e2e/create-post.test.js
+++ b/tests/cypress/e2e/create-post.test.js
@@ -138,7 +138,10 @@ describe('Command: createPost', () => {
     cy.visit('/wp-admin/edit.php?orderby=date&order=desc');
     cy.get('#the-list td.title a.row-title')
       .first()
-      .should('have.text', '(no title)');
+      .should(element => {
+        // WordPress changed the default title for posts without a title at some point.
+        expect(element.text()).to.be.oneOf(['(no title)', 'Untitled']);
+      });
   });
 
   it('Should be able to create Post without content', () => {

--- a/tests/cypress/e2e/create-post.test.js
+++ b/tests/cypress/e2e/create-post.test.js
@@ -128,4 +128,27 @@ describe('Command: createPost', () => {
       );
     });
   });
+
+  it('Should be able to create Post without title', () => {
+    cy.createPost({
+      title: '',
+      content: 'Test Content',
+    });
+
+    cy.visit('/wp-admin/edit.php?orderby=date&order=desc');
+    cy.get('#the-list td.title a.row-title')
+      .first()
+      .should('have.text', '(no title)');
+  });
+
+  it('Should be able to create Post without content', () => {
+    const title = 'No Content Post';
+    cy.createPost({
+      title,
+      content: '',
+    }).then(post => {
+      assert(post.title.raw === title, 'Post title is the same');
+      assert(post.content.rendered.length === 0, 'Post content is empty');
+    });
+  });
 });


### PR DESCRIPTION
### Description of the Change
Adds additional checks to ensure that passing a blank string in as the title or content doesn't cause the test to fail.
This also moves the editor ready check from `titleInput` to `contentInput`, since I've often seen the title hidden on projects, which causes this check to fail.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #94

### How to test the Change
Updated tests are included

### Changelog Entry
Fixed - Issue where passing an empty title or content string to createPost causes an error.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @darylldoyle 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
