### PR TITLE
Add logic and update tests

### DIFF
--- a/src/commands/check-post-exists.ts
+++ b/src/commands/check-post-exists.ts
@@ -32,19 +32,26 @@ export const checkPostExists = ({
 }): void => {
   cy.visit(`/wp-admin/edit.php?post_type=${postType}`);
 
-  const searchInput = '#post-search-input';
-  const searchSubmit = '#search-submit';
-  const postLabel = '[aria-label="Move “' + title + '” to the Trash"]';
-
-  // Search for the post title.
-  cy.get(searchInput).clear().type(title).get(searchSubmit).click();
-
-  // See if the post is listed in the search result.
-  cy.get('body').then($body => {
-    if ($body.find(postLabel).length > 0) {
-      cy.wrap(true);
-    } else {
+  cy.get('#posts-filter').then($postsFilter => {
+    // If there are no posts, bail early.
+    if ($postsFilter.find('.no-items').length > 0) {
       cy.wrap(false);
+    } else {
+      const searchInput = '#post-search-input';
+      const searchSubmit = '#search-submit';
+      const postLabel = '[aria-label="Move “' + title + '” to the Trash"]';
+
+      // Search for the post title.
+      cy.get(searchInput).clear().type(title).get(searchSubmit).click();
+
+      // See if the post is listed in the search result.
+      cy.get('body').then($body => {
+        if ($body.find(postLabel).length > 0) {
+          cy.wrap(true);
+        } else {
+          cy.wrap(false);
+        }
+      });
     }
   });
 };

--- a/tests/cypress/e2e/check-post-exists.test.js
+++ b/tests/cypress/e2e/check-post-exists.test.js
@@ -39,6 +39,23 @@ describe('Command: checkPostExists', () => {
       }
     });
 
+    // Run the tests before seeding any posts to ensure we get false.
+    tests.forEach(test => {
+      it(`${test.postTitle} should not exist`, () => {
+        const args = {
+          title: test.postTitle,
+        };
+
+        // make 'postType' argument optional to test default value
+        if ('post' !== test.postType) {
+          args.postType = test.postType;
+        }
+        cy.checkPostExists(args).then(exists => {
+          assert(exists === false, `Post should not exist`);
+        });
+      });
+    });
+
     // Create posts which expected to exist during tests
     tests.forEach(test => {
       if (test.expected) {
@@ -50,6 +67,7 @@ describe('Command: checkPostExists', () => {
     });
   });
 
+  // Run the tests again after seeding posts to ensure we get the correct response.
   tests.forEach(test => {
     const shouldIt = test.expected ? 'should' : 'should not';
     it(`${test.postTitle} ${shouldIt} exist`, () => {


### PR DESCRIPTION
### Description of the Change
This PR adds an additional check to the `checkPostExists` command to ensure it doesn't incorrectly fail when there are no posts within a post type it's searching on.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #99 99

### How to test the Change
Tested on a project and updated tests

### Changelog Entry
> Fixed - Issue with `checkPostExists` failing when there are no posts within a post type.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @darylldoyle 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
