### PR TITLE
Ensure commands work in the new iframed Block Editor

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         core:
-          - { name: 'WP latest', version: 'latest', number: 'latest' }
+          - { name: 'WP latest', version: 'latest', number: '6.3' }
           - { name: 'WP trunk', version: 'WordPress/WordPress#master', number: '6.3' }
           - { name: 'WP minimum', version: 'WordPress/WordPress#5.7', number: '5.7' }
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: changed-files
-        uses: tj-actions/changed-files@v18.7
+        uses: tj-actions/changed-files@v37
         with:
           files: |
             .github/workflows/cypress.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache Node
         uses: actions/cache@v3
         with:
@@ -65,12 +65,12 @@ jobs:
       fail-fast: false
       matrix:
         core:
-          - { name: 'WP latest', version: 'latest', number: '6.1' }
-          - { name: 'WP trunk', version: 'WordPress/WordPress#master', number: '6.2' }
+          - { name: 'WP latest', version: 'latest', number: 'latest' }
+          - { name: 'WP trunk', version: 'WordPress/WordPress#master', number: '6.3' }
           - { name: 'WP minimum', version: 'WordPress/WordPress#5.7', number: '5.7' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache Node
         uses: actions/cache@v3
         with:
@@ -100,7 +100,7 @@ jobs:
           npx mochawesome-report-generator tests/cypress/reports/mochawesome.json -o tests/cypress/reports/
           cat ./tests/cypress/reports/mochawesome.md >> $GITHUB_STEP_SUMMARY
       - name: Make artifacts available
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-artifact

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,9 +1,11 @@
 {
   "plugins": [
     ".",
-    "WordPress/classic-editor",
-    "https://github.com/10up/retro-winamp-block/releases/download/1.0.1/retro-winamp-block.zip"
+    "WordPress/classic-editor"
   ],
+  "mappings": {
+    "wp-content/plugins/retro-winamp-block": "https://github.com/10up/retro-winamp-block/releases/download/1.0.1/retro-winamp-block.zip"
+  },
   "env": {
     "tests": {
       "mappings": {

--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ npm i -D path/to/the/library
 
 ### Test against every WordPress major release
 
-For every incoming pull request by default on GitHub Actions we automatically perform tests against:
-- current minimum supported WordPress 5.2
+Every incoming pull request will automatically run tests against:
+
+- our current minimum supported WordPress version, 5.7
 - WordPress [latest release](https://github.com/WordPress/WordPress/tags)
 - current WordPress [future release](https://github.com/WordPress/WordPress/tree/master)
 
-To run tests locally against every WordPress major release since minimum support (5.2) to the latest nightly build (e.g., 6.0-alpha) use this script:
+To run tests locally against every WordPress major release since minimum support (5.7) to the latest nightly build (e.g., 6.4s-alpha) use this script:
 
 ```sh
 ./run-all-cores.sh

--- a/README.md
+++ b/README.md
@@ -6,18 +6,12 @@
 
 ## Prerequisites
 
-This library requires Cypress. Use [@10up/cypress-wp-setup](https://github.com/10up/cypress-wp-setup) to set up Cypress automatically, including this library. If running tests against WordPress 6.3, you'll also need to install the [Cypress iframe package](https://gitlab.com/kgroat/cypress-iframe) and you'll probably need to set `chromeWebSecurity: false` in your Cypress config file. This allows Cypress to properly interact with the iframed Block Editor.
+This library requires Cypress. Use [@10up/cypress-wp-setup](https://github.com/10up/cypress-wp-setup) to set up Cypress automatically, including this library. If running tests against WordPress 6.3, you'll probably need to set `chromeWebSecurity: false` in your Cypress config file. This allows Cypress to properly interact with the iframed Block Editor.
 
 ## Installation
 
 ```sh
 npm install @10up/cypress-wp-utils --save-dev
-```
-
-If needed, install the Cypress iframe package:
-
-```sh
-npm install cypress-iframe --save-dev
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,12 +6,18 @@
 
 ## Prerequisites
 
-This library requires Cypress. Use [@10up/cypress-wp-setup](https://github.com/10up/cypress-wp-setup) to set up Cypress automatically, including this library. If running tests against WordPress 6.3, you'll probably need to set `chromeWebSecurity: false` in your Cypress config file. This allows Cypress to properly interact with the iframed Block Editor.
+This library requires Cypress. Use [@10up/cypress-wp-setup](https://github.com/10up/cypress-wp-setup) to set up Cypress automatically, including this library. If running tests against WordPress 6.3, you'll also need to install the [Cypress iframe package](https://gitlab.com/kgroat/cypress-iframe) and you'll probably need to set `chromeWebSecurity: false` in your Cypress config file. This allows Cypress to properly interact with the iframed Block Editor.
 
 ## Installation
 
 ```sh
 npm install @10up/cypress-wp-utils --save-dev
+```
+
+If needed, install the Cypress iframe package:
+
+```sh
+npm install cypress-iframe --save-dev
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Prerequisites
 
-This library requires Cypress. Use [@10up/cypress-wp-setup](https://github.com/10up/cypress-wp-setup) to set up Cypress automatically, including this library.
+This library requires Cypress. Use [@10up/cypress-wp-setup](https://github.com/10up/cypress-wp-setup) to set up Cypress automatically, including this library. If running tests against WordPress 6.3, you'll probably need to set `chromeWebSecurity: false` in your Cypress config file. This allows Cypress to properly interact with the iframed Block Editor.
 
 ## Installation
 
@@ -23,7 +23,7 @@ Import the libary in `support/index.js` file:
 import '@10up/cypress-wp-utils';
 ```
 
-Documentation for commands can be found at https://10up.github.io/cypress-wp-utils/.
+Documentation for commands can be found at [https://10up.github.io/cypress-wp-utils/](https://10up.github.io/cypress-wp-utils/).
 
 ### IntelliSense and code completion for Cypress commands
 
@@ -47,7 +47,7 @@ This project uses `hygen` to scaffold new commands to reduce the effort of manua
 $ npx hygen cypress-command new customCommand
 
 Loaded templates: _templates
-       added: src/commands/custom-command.ts
+      added: src/commands/custom-command.ts
       inject: src/index.ts
       inject: src/index.ts
       inject: src/index.ts
@@ -67,7 +67,7 @@ Every incoming pull request will automatically run tests against:
 - WordPress [latest release](https://github.com/WordPress/WordPress/tags)
 - current WordPress [future release](https://github.com/WordPress/WordPress/tree/master)
 
-To run tests locally against every WordPress major release since minimum support (5.7) to the latest nightly build (e.g., 6.4s-alpha) use this script:
+To run tests locally against every WordPress major release since minimum support (5.7) to the latest nightly build (e.g., 6.4-alpha) use this script:
 
 ```sh
 ./run-all-cores.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "codecov": "^3.8.1",
         "compare-versions": "^4.1.3",
         "cypress": "^10.11.0",
+        "cypress-iframe": "^1.0.1",
         "cypress-mochawesome-reporter": "^3.2.3",
         "eslint": "^7.25.0",
         "eslint-config-prettier": "^8.3.0",
@@ -348,6 +349,17 @@
         "@types/keyv": "*",
         "@types/node": "*",
         "@types/responselike": "*"
+      }
+    },
+    "node_modules/@types/cypress": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
+      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
+      "deprecated": "This is a stub types definition for cypress (https://cypress.io). cypress provides its own type definitions, so you don't need @types/cypress installed!",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "cypress": "*"
       }
     },
     "node_modules/@types/http-cache-semantics": {
@@ -1549,6 +1561,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cypress-iframe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cypress-iframe/-/cypress-iframe-1.0.1.tgz",
+      "integrity": "sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/cypress": "^1.1.0"
       }
     },
     "node_modules/cypress-mochawesome-reporter": {
@@ -6721,6 +6742,16 @@
         "@types/responselike": "*"
       }
     },
+    "@types/cypress": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
+      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "cypress": "*"
+      }
+    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -7663,6 +7694,13 @@
           }
         }
       }
+    },
+    "cypress-iframe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cypress-iframe/-/cypress-iframe-1.0.1.tgz",
+      "integrity": "sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==",
+      "dev": true,
+      "requires": {}
     },
     "cypress-mochawesome-reporter": {
       "version": "3.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "codecov": "^3.8.1",
         "compare-versions": "^4.1.3",
         "cypress": "^10.11.0",
-        "cypress-iframe": "^1.0.1",
         "cypress-mochawesome-reporter": "^3.2.3",
         "eslint": "^7.25.0",
         "eslint-config-prettier": "^8.3.0",
@@ -349,17 +348,6 @@
         "@types/keyv": "*",
         "@types/node": "*",
         "@types/responselike": "*"
-      }
-    },
-    "node_modules/@types/cypress": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
-      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
-      "deprecated": "This is a stub types definition for cypress (https://cypress.io). cypress provides its own type definitions, so you don't need @types/cypress installed!",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "cypress": "*"
       }
     },
     "node_modules/@types/http-cache-semantics": {
@@ -1561,15 +1549,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/cypress-iframe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cypress-iframe/-/cypress-iframe-1.0.1.tgz",
-      "integrity": "sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==",
-      "dev": true,
-      "peerDependencies": {
-        "@types/cypress": "^1.1.0"
       }
     },
     "node_modules/cypress-mochawesome-reporter": {
@@ -6742,16 +6721,6 @@
         "@types/responselike": "*"
       }
     },
-    "@types/cypress": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/cypress/-/cypress-1.1.3.tgz",
-      "integrity": "sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "cypress": "*"
-      }
-    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -7694,13 +7663,6 @@
           }
         }
       }
-    },
-    "cypress-iframe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cypress-iframe/-/cypress-iframe-1.0.1.tgz",
-      "integrity": "sha512-Ne+xkZmWMhfq3x6wbfzK/SzsVTCrJru3R3cLXsoSAZyfUtJDamXyaIieHXeea3pQDXF4wE2w4iUuvCYHhoD31g==",
-      "dev": true,
-      "requires": {}
     },
     "cypress-mochawesome-reporter": {
       "version": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prettify": "prettier --write \"**/*.{ts,js}\"",
     "typecheck": "tsc --noEmit",
     "cypress:open": "cypress open --config-file tests/cypress/cypress-config.js --e2e --browser chrome",
-    "cypress:run": "cypress run --config-file tests/cypress/cypress-config.js",
+    "cypress:run": "cypress run --config-file tests/cypress/cypress-config.js --e2e --browser chrome",
     "env": "wp-env",
     "env:start": "wp-env start",
     "env:stop": "wp-env stop",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "codecov": "^3.8.1",
     "compare-versions": "^4.1.3",
     "cypress": "^10.11.0",
-    "cypress-iframe": "^1.0.1",
     "cypress-mochawesome-reporter": "^3.2.3",
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prettify": "prettier --write \"**/*.{ts,js}\"",
     "typecheck": "tsc --noEmit",
     "cypress:open": "cypress open --config-file tests/cypress/cypress-config.js --e2e --browser chrome",
-    "cypress:run": "cypress run --config-file tests/cypress/cypress-config.js --e2e --browser chrome",
+    "cypress:run": "cypress run --config-file tests/cypress/cypress-config.js",
     "env": "wp-env",
     "env:start": "wp-env start",
     "env:stop": "wp-env stop",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "env": "wp-env",
     "env:start": "wp-env start",
     "env:stop": "wp-env stop",
+    "env:destroy": "wp-env destroy",
     "postenv:start": "./tests/bin/initialize.sh"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "codecov": "^3.8.1",
     "compare-versions": "^4.1.3",
     "cypress": "^10.11.0",
+    "cypress-iframe": "^1.0.1",
     "cypress-mochawesome-reporter": "^3.2.3",
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.3.0",

--- a/run-all-cores.sh
+++ b/run-all-cores.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSIONS="5.7 5.8 5.9 6.0 6.1 master:6.2"
+VERSIONS="5.7 5.8 5.9 6.0 6.1 6.2 master:6.3"
 
 SPEC="-- --quiet"
 

--- a/src/commands/close-welcome-guide.ts
+++ b/src/commands/close-welcome-guide.ts
@@ -12,7 +12,7 @@ export const closeWelcomeGuide = (): void => {
     '.edit-post-welcome-guide .components-modal__header button';
 
   // Wait for edit page to load
-  cy.get(titleInput).should('exist');
+  cy.getBlockEditor().find(titleInput).should('exist');
 
   cy.get('body').then($body => {
     if ($body.find(closeButtonSelector).length > 0) {

--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -67,20 +67,20 @@ export const createPost = ({
   const titleInput = 'h1.editor-post-title__input, #post-title-0';
   const contentInput = '.block-editor-default-block-appender__content';
 
-  // Make sure editor loaded properly.
-  cy.get(contentInput).should('exist');
-
   // Close Welcome Guide.
   cy.closeWelcomeGuide();
 
   // Fill out data.
   if (title.length > 0) {
-    cy.get(titleInput).clear().type(title);
+    cy.getBlockEditor().find(titleInput).clear().type(title);
   }
 
   if (content.length > 0) {
-    cy.get(contentInput).click();
-    cy.get('.block-editor-rich-text__editable').first().type(content);
+    cy.getBlockEditor().find(contentInput).click();
+    cy.getBlockEditor()
+      .find('.block-editor-rich-text__editable')
+      .first()
+      .type(content);
   }
 
   if ('undefined' !== typeof beforeSave) {

--- a/src/commands/get-block-editor.ts
+++ b/src/commands/get-block-editor.ts
@@ -1,0 +1,25 @@
+/**
+ * Get the Block Editor
+ *
+ * @returns Block Editor element.
+ *
+ * @example
+ * Find the title input and type in it
+ * ```
+ * cy.getBlockEditor().find('.editor-post-title__input').type('Test Post');
+ * ```
+ */
+export const getBlockEditor = (): Cypress.Chainable<unknown> => {
+  // Ensure the editor is loaded.
+  cy.get('.edit-post-visual-editor').should('exist');
+
+  return cy
+    .get('body')
+    .then($body => {
+      if ($body.find('iframe[name="editor-canvas"]').length) {
+        return cy.iframe('iframe[name="editor-canvas"]');
+      }
+      return $body;
+    })
+    .then(cy.wrap); // eslint-disable-line @typescript-eslint/unbound-method
+};

--- a/src/commands/get-block-editor.ts
+++ b/src/commands/get-block-editor.ts
@@ -1,3 +1,5 @@
+import { getIframe } from '../functions/get-iframe';
+
 /**
  * Get the Block Editor
  *
@@ -17,7 +19,7 @@ export const getBlockEditor = (): Cypress.Chainable<unknown> => {
     .get('body')
     .then($body => {
       if ($body.find('iframe[name="editor-canvas"]').length) {
-        return cy.iframe('iframe[name="editor-canvas"]');
+        return getIframe('iframe[name="editor-canvas"]');
       }
       return $body;
     })

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -39,20 +39,18 @@ export const insertBlock = (type: string, name?: string): void => {
   // Remove block patterns
   /* eslint-disable */
   let patterns: any[] = [];
-  cy.window()
-    .then(win => {
-      const settings = win.wp.data.select('core/block-editor').getSettings();
-      patterns = settings?.__experimentalBlockPatterns || [];
-      if (patterns.length > 0) {
-        win.wp.data
-          .select('core/block-editor')
-          .getSettings().__experimentalBlockPatterns = [];
-      }
-    })
-    .as('patternsRemoved');
-  /* eslint-enable */
+  cy.window().then(win => {
+    const settings = win.wp.data.select('core/block-editor').getSettings();
+    patterns = settings?.__experimentalBlockPatterns || [];
+    if (patterns.length > 0) {
+      win.wp.data
+        .select('core/block-editor')
+        .getSettings().__experimentalBlockPatterns = [];
+    }
+  });
 
-  cy.wait('@patternsRemoved');
+  cy.wait(500);
+  /* eslint-enable */
 
   // Open blocks panel
   cy.get(
@@ -81,16 +79,14 @@ export const insertBlock = (type: string, name?: string): void => {
 
   // Add patterns back
   /* eslint-disable */
-  cy.window()
-    .then(win => {
-      win.wp.data
-        .select('core/block-editor')
-        .getSettings().__experimentalBlockPatterns = patterns || [];
-    })
-    .as('patternsAdded');
-  /* eslint-enable */
+  cy.window().then(win => {
+    win.wp.data
+      .select('core/block-editor')
+      .getSettings().__experimentalBlockPatterns = patterns || [];
+  });
 
-  cy.wait('@patternsAdded');
+  cy.wait(500);
+  /* eslint-enable */
 
   // Remove tailing suffix of sub-blocks
   const blockType = type.replace(/^(.*?)\/(.*?)\/[^/]+$/, '$1/$2');

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -43,10 +43,7 @@ export const insertBlock = (type: string, name?: string): void => {
     '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
   ).click();
 
-  cy.get('.block-editor-inserter__search')
-    .click()
-    .type(search)
-    .type('{enter}', { delay: 500 });
+  cy.get('.block-editor-inserter__search').click().type(search);
 
   // Insert the block
   cy.get(`.editor-block-list-item-${slug}, .editor-block-list-item-${slugAlt}`)
@@ -69,21 +66,46 @@ export const insertBlock = (type: string, name?: string): void => {
   const blockTypeAlt = type.replace('/', '-');
 
   // Get last block of the current type
+  // Pull from the iframe editor first, if it exists
   cy.get('body').then($body => {
-    if ($body.find(`.wp-block[data-type="${blockType}"]`).length > 0) {
-      cy.get(`.wp-block[data-type="${blockType}"]`)
-        .last()
-        .then(block => {
-          const id = block.prop('id');
-          cy.wrap(id);
-        });
-    } else if ($body.find(`.wp-block[data-type="${blockTypeAlt}"]`)) {
-      cy.get(`.wp-block[data-type="${blockTypeAlt}"]`)
-        .last()
-        .then(block => {
-          const id = block.prop('id');
-          cy.wrap(id);
-        });
+    if ($body.find('iframe[name="editor-canvas"]').length) {
+      cy.iframe('iframe[name="editor-canvas"]').then($iframe => {
+        if ($iframe.find(`.wp-block[data-type="${blockType}"]`).length > 0) {
+          cy.iframe('iframe[name="editor-canvas"]')
+            .find(`.wp-block[data-type="${blockType}"]`)
+            .last()
+            .then(block => {
+              const id = block.prop('id');
+              cy.wrap(id);
+            });
+        } else if (
+          $iframe.find(`.wp-block[data-type="${blockTypeAlt}"]`).length
+        ) {
+          cy.iframe('iframe[name="editor-canvas"]')
+            .find(`.wp-block[data-type="${blockTypeAlt}"]`)
+            .last()
+            .then(block => {
+              const id = block.prop('id');
+              cy.wrap(id);
+            });
+        }
+      });
+    } else {
+      if ($body.find(`.wp-block[data-type="${blockType}"]`).length > 0) {
+        cy.get(`.wp-block[data-type="${blockType}"]`)
+          .last()
+          .then(block => {
+            const id = block.prop('id');
+            cy.wrap(id);
+          });
+      } else if ($body.find(`.wp-block[data-type="${blockTypeAlt}"]`)) {
+        cy.get(`.wp-block[data-type="${blockTypeAlt}"]`)
+          .last()
+          .then(block => {
+            const id = block.prop('id');
+            cy.wrap(id);
+          });
+      }
     }
   });
 };

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -39,13 +39,12 @@ export const insertBlock = (type: string, name?: string): void => {
   // Remove block patterns
   /* eslint-disable */
   let patterns: any[] = [];
+  let settings: any = {};
   cy.window().then(win => {
-    const settings = win.wp.data.select('core/block-editor').getSettings();
+    settings = win.wp.data.select('core/block-editor').getSettings();
     patterns = settings?.__experimentalBlockPatterns || [];
     if (patterns.length > 0) {
-      win.wp.data
-        .select('core/block-editor')
-        .getSettings().__experimentalBlockPatterns = [];
+      settings.__experimentalBlockPatterns = [];
     }
   });
 
@@ -78,15 +77,10 @@ export const insertBlock = (type: string, name?: string): void => {
   });
 
   // Add patterns back
-  /* eslint-disable */
-  cy.window().then(win => {
-    win.wp.data
-      .select('core/block-editor')
-      .getSettings().__experimentalBlockPatterns = patterns || [];
-  });
-
-  cy.wait(500);
-  /* eslint-enable */
+  if (patterns.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    settings.__experimentalBlockPatterns = patterns;
+  }
 
   // Remove tailing suffix of sub-blocks
   const blockType = type.replace(/^(.*?)\/(.*?)\/[^/]+$/, '$1/$2');

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -1,5 +1,3 @@
-import { fail } from 'assert';
-
 /**
  * Inserts Block
  *
@@ -38,6 +36,24 @@ export const insertBlock = (type: string, name?: string): void => {
     }
   }
 
+  // Remove block patterns
+  /* eslint-disable */
+  let patterns: any[] = [];
+  cy.window()
+    .then(win => {
+      const settings = win.wp.data.select('core/block-editor').getSettings();
+      patterns = settings?.__experimentalBlockPatterns || [];
+      if (patterns.length > 0) {
+        win.wp.data
+          .select('core/block-editor')
+          .getSettings().__experimentalBlockPatterns = [];
+      }
+    })
+    .as('patternsRemoved');
+  /* eslint-enable */
+
+  cy.wait('@patternsRemoved');
+
   // Open blocks panel
   cy.get(
     '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
@@ -62,6 +78,19 @@ export const insertBlock = (type: string, name?: string): void => {
       cy.get('.edit-post-header-toolbar__inserter-toggle.is-pressed').click();
     }
   });
+
+  // Add patterns back
+  /* eslint-disable */
+  cy.window()
+    .then(win => {
+      win.wp.data
+        .select('core/block-editor')
+        .getSettings().__experimentalBlockPatterns = patterns || [];
+    })
+    .as('patternsAdded');
+  /* eslint-enable */
+
+  cy.wait('@patternsAdded');
 
   // Remove tailing suffix of sub-blocks
   const blockType = type.replace(/^(.*?)\/(.*?)\/[^/]+$/, '$1/$2');

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -1,3 +1,5 @@
+import { getIframe } from '../functions/get-iframe';
+
 /**
  * Inserts Block
  *
@@ -91,9 +93,9 @@ export const insertBlock = (type: string, name?: string): void => {
   // Pull from the iframe editor first, if it exists
   cy.get('body').then($body => {
     if ($body.find('iframe[name="editor-canvas"]').length) {
-      cy.iframe('iframe[name="editor-canvas"]').then($iframe => {
+      getIframe('iframe[name="editor-canvas"]').then($iframe => {
         if ($iframe.find(`.wp-block[data-type="${blockType}"]`).length > 0) {
-          cy.iframe('iframe[name="editor-canvas"]')
+          getIframe('iframe[name="editor-canvas"]')
             .find(`.wp-block[data-type="${blockType}"]`)
             .last()
             .then(block => {
@@ -103,7 +105,7 @@ export const insertBlock = (type: string, name?: string): void => {
         } else if (
           $iframe.find(`.wp-block[data-type="${blockTypeAlt}"]`).length
         ) {
-          cy.iframe('iframe[name="editor-canvas"]')
+          getIframe('iframe[name="editor-canvas"]')
             .find(`.wp-block[data-type="${blockTypeAlt}"]`)
             .last()
             .then(block => {

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -43,7 +43,10 @@ export const insertBlock = (type: string, name?: string): void => {
     '.edit-post-header-toolbar__inserter-toggle, .edit-post-header-toolbar .block-editor-inserter__toggle'
   ).click();
 
-  cy.get('.block-editor-inserter__search').click().type(search);
+  cy.get('.block-editor-inserter__search')
+    .click()
+    .type(search)
+    .type('{enter}', { delay: 500 });
 
   // Insert the block
   cy.get(`.editor-block-list-item-${slug}, .editor-block-list-item-${slugAlt}`)

--- a/src/functions/get-iframe.ts
+++ b/src/functions/get-iframe.ts
@@ -1,0 +1,119 @@
+/**
+ * Code taken from the Cypress iframe package.
+ *
+ * https://gitlab.com/kgroat/cypress-iframe
+ */
+
+const DEFAULT_OPTS: Cypress.Loggable & Cypress.Timeoutable = {
+  log: true,
+  timeout: 30000,
+};
+
+const DEFAULT_IFRAME_SELECTOR = 'iframe';
+
+function sleep(timeout: number) {
+  return new Promise(resolve => setTimeout(resolve, timeout));
+}
+
+const frameLoaded: Cypress.Chainable['frameLoaded'] = (
+  selector?: string | Partial<Cypress.IframeOptions>,
+  opts?: Partial<Cypress.IframeOptions>
+) => {
+  if (selector === undefined) {
+    selector = DEFAULT_IFRAME_SELECTOR;
+  } else if (typeof selector === 'object') {
+    opts = selector;
+    selector = DEFAULT_IFRAME_SELECTOR;
+  }
+
+  const fullOpts: Cypress.IframeOptions = {
+    ...DEFAULT_OPTS,
+    ...opts,
+  };
+
+  const log = fullOpts.log
+    ? Cypress.log({
+        name: 'frame loaded',
+        displayName: 'frame loaded',
+        message: [selector],
+      }).snapshot()
+    : null;
+
+  return cy
+    .get(selector, { log: false })
+    .then(
+      { timeout: fullOpts.timeout },
+      async ($frame: JQuery<HTMLElement>) => {
+        log?.set('$el', $frame);
+
+        if ($frame.length !== 1) {
+          throw new Error(
+            `cypress-iframe commands can only be applied to exactly one iframe at a time. Instead found ${$frame.length}`
+          );
+        }
+
+        const contentWindow: Window = $frame.prop('contentWindow');
+
+        const hasNavigated = fullOpts.url
+          ? () =>
+              typeof fullOpts.url === 'string'
+                ? contentWindow.location.toString().includes(fullOpts.url)
+                : fullOpts.url?.test(contentWindow.location.toString())
+          : () => contentWindow.location.toString() !== 'about:blank';
+
+        while (!hasNavigated()) {
+          await sleep(100);
+        }
+
+        if (contentWindow.document.readyState === 'complete') {
+          return $frame;
+        }
+
+        const loadLog = Cypress.log({
+          name: 'Frame Load',
+          message: [contentWindow.location.toString()],
+          event: true,
+        } as any).snapshot();
+
+        await new Promise(resolve => {
+          Cypress.$(contentWindow).on('load', resolve);
+        });
+
+        loadLog.end();
+        log?.finish();
+
+        return $frame;
+      }
+    );
+};
+
+export const getIframe: Cypress.Chainable['iframe'] = (
+  selector?: string | Partial<Cypress.IframeOptions>,
+  opts?: Partial<Cypress.IframeOptions>
+) => {
+  if (selector === undefined) {
+    selector = DEFAULT_IFRAME_SELECTOR;
+  } else if (typeof selector === 'object') {
+    opts = selector;
+    selector = DEFAULT_IFRAME_SELECTOR;
+  }
+
+  const fullOpts: Cypress.IframeOptions = {
+    ...DEFAULT_OPTS,
+    ...opts,
+  };
+
+  const log = fullOpts.log
+    ? Cypress.log({
+        name: 'iframe',
+        displayName: 'iframe',
+        message: [selector],
+      }).snapshot()
+    : null;
+
+  return frameLoaded(selector, { ...fullOpts, log: false }).then($frame => {
+    log?.set('$el', $frame).end();
+    const contentWindow: Window = $frame.prop('contentWindow');
+    return Cypress.$(contentWindow.document.body as HTMLBodyElement);
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /// <reference types="cypress" />
 
-import 'cypress-iframe';
-
 // Import commands.
 import { checkPostExists } from './commands/check-post-exists';
 import { classicCreatePost } from './commands/classic-create-post';
@@ -52,6 +50,17 @@ declare global {
       login: typeof login;
       checkSitemap: typeof checkSitemap;
       getBlockEditor: typeof getBlockEditor;
+      frameLoaded: IframeHandler<JQuery<HTMLElement>>;
+      iframe: IframeHandler<JQuery<HTMLBodyElement>>;
+    }
+
+    interface IframeHandler<T> {
+      (options?: Partial<IframeOptions>): Chainable<T>;
+      (selector: string, options?: Partial<IframeOptions>): Chainable<T>;
+    }
+
+    interface IframeOptions extends Loggable, Timeoutable {
+      url?: RegExp | string;
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /// <reference types="cypress" />
 
+import 'cypress-iframe';
+
 // Import commands.
 import { checkPostExists } from './commands/check-post-exists';
 import { classicCreatePost } from './commands/classic-create-post';
@@ -23,6 +25,7 @@ import { login } from './commands/login';
 import { createPost } from './commands/create-post';
 import { uploadMedia } from './commands/upload-media';
 import { checkSitemap } from './commands/check-sitemap-exists';
+import { getBlockEditor } from './commands/get-block-editor';
 
 declare global {
   namespace Cypress {
@@ -48,6 +51,7 @@ declare global {
       logout: typeof logout;
       login: typeof login;
       checkSitemap: typeof checkSitemap;
+      getBlockEditor: typeof getBlockEditor;
     }
   }
 }
@@ -77,3 +81,4 @@ Cypress.Commands.add('uploadMedia', uploadMedia);
 Cypress.Commands.add('logout', logout);
 Cypress.Commands.add('login', login);
 Cypress.Commands.add('checkSitemap', checkSitemap);
+Cypress.Commands.add('getBlockEditor', getBlockEditor);

--- a/tests/cypress/cypress-config.js
+++ b/tests/cypress/cypress-config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require('cypress');
 const { readConfig } = require('@wordpress/env/lib/config');
 
 module.exports = defineConfig({
+  chromeWebSecurity: false,
   fixturesFolder: 'tests/cypress/fixtures',
   screenshotsFolder: 'tests/cypress/screenshots',
   videosFolder: 'tests/cypress/videos',

--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -28,7 +28,7 @@ describe('Command: insertBlock', () => {
     });
 
     cy.getBlockEditor()
-      .find('.wp-block-post-content')
+      .find('.wp-block-post-content, .block-editor-writing-flow')
       .should('contain.text', paragraph);
   });
 
@@ -43,7 +43,7 @@ describe('Command: insertBlock', () => {
     });
 
     cy.getBlockEditor()
-      .find('.wp-block-post-content h2')
+      .find('.wp-block-post-content h2, .block-editor-writing-flow h2')
       .should('contain.text', heading);
   });
 
@@ -94,6 +94,8 @@ describe('Command: insertBlock', () => {
       return;
     }
 
+    cy.activatePlugin('retro-winamp-block');
+
     cy.createPost({
       beforeSave: () => {
         cy.insertBlock('tenup/winamp-block', 'WinAmp');
@@ -105,5 +107,7 @@ describe('Command: insertBlock', () => {
       .should('contain.text', 'Add Audio')
       .should('have.attr', 'data-type')
       .and('eq', 'tenup/winamp-block');
+
+    cy.deactivatePlugin('retro-winamp-block');
   });
 });

--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -22,12 +22,14 @@ describe('Command: insertBlock', () => {
     cy.createPost({
       beforeSave: () => {
         cy.insertBlock('core/paragraph').then(id => {
-          cy.get(`#${id}`).click().type(paragraph);
+          cy.getBlockEditor().find(`#${id}`).click().type(paragraph);
         });
       },
     });
 
-    cy.get('.block-editor-writing-flow').should('contain.text', paragraph);
+    cy.getBlockEditor()
+      .find('.wp-block-post-content')
+      .should('contain.text', paragraph);
   });
 
   it('Should be able to Insert Heading', () => {
@@ -35,12 +37,14 @@ describe('Command: insertBlock', () => {
     cy.createPost({
       beforeSave: () => {
         cy.insertBlock('core/heading').then(id => {
-          cy.get(`#${id}`).click().type(heading);
+          cy.getBlockEditor().find(`#${id}`).click().type(heading);
         });
       },
     });
 
-    cy.get('.block-editor-writing-flow h2').should('contain.text', heading);
+    cy.getBlockEditor()
+      .find('.wp-block-post-content h2')
+      .should('contain.text', heading);
   });
 
   it('Should be able to insert Pullquote', () => {
@@ -49,21 +53,24 @@ describe('Command: insertBlock', () => {
     cy.createPost({
       beforeSave: () => {
         cy.insertBlock('core/pullquote').then(id => {
-          cy.get(
-            `#${id} [aria-label="Pullquote text"], #${id} [aria-label="Write quote…"]`
-          )
+          cy.getBlockEditor()
+            .find(
+              `#${id} [aria-label="Pullquote text"], #${id} [aria-label="Write quote…"]`
+            )
             .click()
             .type(quote);
-          cy.get(
-            `#${id} [aria-label="Pullquote citation text"], #${id} [aria-label="Write citation…"]`
-          )
+          cy.getBlockEditor()
+            .find(
+              `#${id} [aria-label="Pullquote citation text"], #${id} [aria-label="Write citation…"]`
+            )
             .click()
             .type(cite);
         });
       },
     });
 
-    cy.get('.wp-block-pullquote')
+    cy.getBlockEditor()
+      .find('.wp-block-pullquote')
       .should('contain.text', quote)
       .should('contain.text', cite);
   });
@@ -75,7 +82,9 @@ describe('Command: insertBlock', () => {
       },
     });
 
-    cy.get('.wp-block-embed').should('contain.text', 'Twitter');
+    cy.getBlockEditor()
+      .find('.wp-block-embed')
+      .should('contain.text', 'Twitter');
   });
 
   it('Should be able to insert custom block', () => {
@@ -91,7 +100,8 @@ describe('Command: insertBlock', () => {
       },
     });
 
-    cy.get('.wp-block-tenup-winamp-block')
+    cy.getBlockEditor()
+      .find('.wp-block-tenup-winamp-block')
       .should('contain.text', 'Add Audio')
       .should('have.attr', 'data-type')
       .and('eq', 'tenup/winamp-block');

--- a/tests/cypress/e2e/open-document-settings.test.js
+++ b/tests/cypress/e2e/open-document-settings.test.js
@@ -129,13 +129,32 @@ describe('Commands: openDocumentSettings*', () => {
       cy.closeWelcomeGuide();
 
       cy.get('body').then($body => {
-        if ($body.find('.wp-block-post-content > .wp-block').length > 0) {
-          cy.get('.wp-block-post-content > .wp-block').first().click();
+        if ($body.find('iframe[name="editor-canvas"]').length) {
+          if (
+            cy
+              .iframe('iframe[name="editor-canvas"]')
+              .find('.wp-block-post-content > .wp-block').length > 0
+          ) {
+            cy.iframe('iframe[name="editor-canvas"]')
+              .find('.wp-block-post-content > .wp-block')
+              .first()
+              .click();
+          } else {
+            // Fallback for WordPress 5.7
+            cy.iframe('iframe[name="editor-canvas"]')
+              .find('.block-editor-block-list__layout > .wp-block')
+              .first()
+              .click();
+          }
         } else {
-          // Fallback for WordPress 5.7
-          cy.get('.block-editor-block-list__layout > .wp-block')
-            .first()
-            .click();
+          if ($body.find('.wp-block-post-content > .wp-block').length > 0) {
+            cy.get('.wp-block-post-content > .wp-block').first().click();
+          } else {
+            // Fallback for WordPress 5.7
+            cy.get('.block-editor-block-list__layout > .wp-block')
+              .first()
+              .click();
+          }
         }
       });
 

--- a/tests/cypress/e2e/open-document-settings.test.js
+++ b/tests/cypress/e2e/open-document-settings.test.js
@@ -1,4 +1,5 @@
 const { randomName } = require('../support/functions');
+import { getIframe } from '../../../lib/functions/get-iframe';
 
 describe('Commands: openDocumentSettings*', () => {
   before(() => {
@@ -131,17 +132,17 @@ describe('Commands: openDocumentSettings*', () => {
       cy.get('body').then($body => {
         if ($body.find('iframe[name="editor-canvas"]').length) {
           if (
-            cy
-              .iframe('iframe[name="editor-canvas"]')
-              .find('.wp-block-post-content > .wp-block').length > 0
+            getIframe('iframe[name="editor-canvas"]').find(
+              '.wp-block-post-content > .wp-block'
+            ).length > 0
           ) {
-            cy.iframe('iframe[name="editor-canvas"]')
+            getIframe('iframe[name="editor-canvas"]')
               .find('.wp-block-post-content > .wp-block')
               .first()
               .click();
           } else {
             // Fallback for WordPress 5.7
-            cy.iframe('iframe[name="editor-canvas"]')
+            getIframe('iframe[name="editor-canvas"]')
               .find('.block-editor-block-list__layout > .wp-block')
               .first()
               .click();


### PR DESCRIPTION
### Description of the Change

In WordPress 6.3, the Block Editor now loads in an iframe by default. Any commands that interact with the Block Editor will now fail in that state, so this PR updates those commands to utilize the iframe element, if it exists.

A new `getBlockEditor` command has been added that will return either the main `body` element or the `iframe` element, depending on which one exists. We then utilize this a few places to ensure we're targeting the right element.

We also set `chromeWebSecurity` to `false`, which allows Cypress to load the `iframe`. Important to note that for any project using this tool, they'll probably need to set that config value themselves as well.

Finally we update the versions of WordPress we run E2E tests on to ensure we're testing 6.3

Closes #104, #91, #101

### How to test the Change

Ensure E2E tests are passing.

In addition, feel free to pull these changes into other projects and ensure E2E tests for those projects pass as well.

### Changelog Entry

> Added - New command, `getBlockEditor`, which returns the proper editor element.
> Changed - Update the versions of WordPress we test on to include 6.3
> Fixed - Ensure all E2E tests pass when running on WordPress 6.3

### Credits

Props @dkotter, @iamdharmesh, @TylerB24890 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
