### PR TITLE
Validate login by checking current user profile

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           files: |
             .github/workflows/cypress.yml
-            src/*
-            tests/*
+            src/**
+            tests/**
             cypress-wp-utils.php
             .wp-env.json
             package.json

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -17,14 +17,23 @@
  * ```
  */
 export const login = (username = 'admin', password = 'password'): void => {
-  cy.session([username, password], () => {
-    cy.visit('/wp-admin/');
-    cy.get('body').then($body => {
-      if ($body.find('#wpwrap').length == 0) {
-        cy.get('input#user_login').clear();
-        cy.get('input#user_login').click().type(username);
-        cy.get('input#user_pass').type(`${password}{enter}`);
-      }
-    });
-  });
+  cy.session(
+    [username, password],
+    () => {
+      cy.visit('/wp-admin/');
+      cy.get('body').then($body => {
+        if ($body.find('#wpwrap').length == 0) {
+          cy.get('input#user_login').clear();
+          cy.get('input#user_login').click().type(username);
+          cy.get('input#user_pass').type(`${password}{enter}`);
+        }
+      });
+    },
+    {
+      validate() {
+        cy.visit('/wp-admin/profile.php');
+        cy.get('#user_login').should('have.value', username);
+      },
+    }
+  );
 };

--- a/tests/bin/initialize.sh
+++ b/tests/bin/initialize.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 npm run env run tests-wordpress "chmod -c ugo+w /var/www/html"
 npm run env run tests-cli "wp rewrite structure '/%postname%/' --hard"
+
+npm run env run tests-cli "wp user create user1 user1@example.test --role=author --user_pass=password1"
+npm run env run tests-cli "wp user create user2 user2@example.test --role=author --user_pass=password2"

--- a/tests/cypress/e2e/login.test.js
+++ b/tests/cypress/e2e/login.test.js
@@ -8,4 +8,10 @@ describe('Command: login', () => {
     cy.visit('/wp-admin');
     cy.get('h1').should('contain', 'Dashboard');
   });
+
+  it('Switch users', () => {
+    cy.login('user1', 'password1');
+    cy.login('user2', 'password2');
+    cy.login();
+  });
 });


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Adds session validation to the `login` command. The validation is performed by visiting user profile and checking the "Login" field value to match the user which needs to be logged in.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #111 

### How to test the Change
Added new test to switch between multiple user sessions.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Session validation for login command

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @cadic, @darylldoyle 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
