### PR TITLE
Ensure the publish/save button isn't disabled before clicking on it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-tsdoc": "^0.2.14",
         "husky": "^6.0.0",
         "lint-staged": "^13.2.1",
+        "mochawesome-json-to-md": "^0.7.2",
         "prettier": "^2.2.1",
         "ts-node": "^10.2.1",
         "typedoc": "^0.22.12",
@@ -4482,6 +4483,19 @@
       },
       "peerDependencies": {
         "mocha": ">=7"
+      }
+    },
+    "node_modules/mochawesome-json-to-md": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/mochawesome-json-to-md/-/mochawesome-json-to-md-0.7.2.tgz",
+      "integrity": "sha512-dxh+o73bhC6nEph6fNky9wy35R+2oK3ueXwAlJ/COAanlFgu8GuvGzQ00VNO4PPYhYGDsO4vbt4QTcMA3lv25g==",
+      "deprecated": "🙌 Thanks for using it. We recommend upgrading to the newer version, 1.x.x. Check out https://www.npmjs.com/package/mochawesome-json-to-md for details.",
+      "dev": true,
+      "dependencies": {
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "mochawesome-json-to-md": "index.js"
       }
     },
     "node_modules/mochawesome-merge": {
@@ -9889,6 +9903,15 @@
           "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
           "dev": true
         }
+      }
+    },
+    "mochawesome-json-to-md": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/mochawesome-json-to-md/-/mochawesome-json-to-md-0.7.2.tgz",
+      "integrity": "sha512-dxh+o73bhC6nEph6fNky9wy35R+2oK3ueXwAlJ/COAanlFgu8GuvGzQ00VNO4PPYhYGDsO4vbt4QTcMA3lv25g==",
+      "dev": true,
+      "requires": {
+        "yargs": "^17.0.1"
       }
     },
     "mochawesome-merge": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-tsdoc": "^0.2.14",
     "husky": "^6.0.0",
     "lint-staged": "^13.2.1",
+    "mochawesome-json-to-md": "^0.7.2",
     "prettier": "^2.2.1",
     "ts-node": "^10.2.1",
     "typedoc": "^0.22.12",

--- a/src/commands/classic-create-post.ts
+++ b/src/commands/classic-create-post.ts
@@ -45,9 +45,9 @@ export const classicCreatePost = ({
   });
 
   if ('draft' === status) {
-    cy.get('#save-post').click();
+    cy.get('#save-post').should('not.have.class', 'disabled').click();
   } else {
-    cy.get('#publish').click();
+    cy.get('#publish').should('not.have.class', 'disabled').click();
   }
 
   cy.wait('@savePost').then(response => {


### PR DESCRIPTION
### Description of the Change

As described in #115, the `classicCreatePost` command can sometimes fail if autosaving takes too long. When an autosave happens, WordPress adds the `disabled` class to the publish button. Once autosave is done, that class is removed. But if our test runs quicker than the autosave, we try clicking the button and nothing happens and our test then fails because the `savePost` alias never fires.

This PR attempts to fix that by ensuring this button does not have the `disabled` class before we try clicking it

Closes #115

### How to test the Change

Run a test that uses the `classicCreatePost` command and ensure it works as expected

### Changelog Entry

> Fixed - Ensure the publish button isn't disabled before we click it in the `classicCreatePost` command

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
