### PR TITLE
Restore permalink structure to default after tests.

### DIFF
--- a/tests/cypress/e2e/set-permalink-structure.test.js
+++ b/tests/cypress/e2e/set-permalink-structure.test.js
@@ -48,7 +48,7 @@ describe('Command: setPermalinkStructure', () => {
   });
 
   after(() => {
-    // Set permalinks back to plain
-    cy.setPermalinkStructure('');
+    // Restore default permalink structure.
+    cy.setPermalinkStructure('/%postname%/');
   });
 });


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Modifies the permalink structure test's `after()` routine to match the permalink structure defined during initialization. This is to ensure the permalink tests to not break other tests expecting the default permalink structure.

https://github.com/10up/cypress-wp-utils/blob/40c6b52a80dccbbc1cad83a7d679811671145878/tests/bin/initialize.sh#L3

Closes #119.

### How to test the Change

1. Run `CYPRESS_WORDPRESS_CORE=x.x npm run cypress:open` where x.x is the version of WordPress you a testing with.
2. Run the check-sitemap-exists tests, these should pass
3. Run the set-permalink-structure tests, these should pass
4. Re-run the check-sitemap-exists tests, these should pass (on the `develop` branch this second run will fail)


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Permalink tests clean up routine.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
