### PR TITLE
Add new versions to all run-all-cores.sh script.

### DIFF
--- a/run-all-cores.sh
+++ b/run-all-cores.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-VERSIONS="5.7 5.8 5.9 6.0 6.1 6.2 master:6.3"
+MAJOR_VERSIONS="5.7 5.8 5.9 6.0 6.1 6.2 6.3 6.4"
+TRUNK="master:6.5"
+
+VERSIONS=""
+for MAJOR_VERSION in $MAJOR_VERSIONS; do
+	# This ensures the latest patch version is used.
+	VERSIONS="$VERSIONS $MAJOR_VERSION-branch:$MAJOR_VERSION"
+done
+VERSIONS="$TRUNK $VERSIONS"
+
+echo "Running tests for the following core versions: $VERSIONS"
 
 SPEC="-- --quiet"
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Updates the `run-all-cores.sh` script to include WordPress 6.4 and 6.5 (trunk).

Modifies the generation of the VERSIONS variable to ensure the latest patch version of WordPress is run.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #121

### How to test the Change

1. Ensure docker is running
2. Run the run-all-cores.sh script in your CLI

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Update version numbers in `run-all-cores.sh` script to include latest versions of WP.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
