### PR TITLE
Ensure that the `insertBlock` command works properly in all cases.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^12.20.11",
         "@typescript-eslint/eslint-plugin": "^4.22.0",
         "@typescript-eslint/parser": "^4.22.0",
-        "@wordpress/env": "^5.5.0",
+        "@wordpress/env": "^10.2.0",
         "codecov": "^3.8.1",
         "compare-versions": "^4.1.3",
         "cypress": "^13.6.4",
@@ -657,14 +657,14 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.16.0.tgz",
-      "integrity": "sha512-zx6UO8PuJBrQ34cfeedK1HlGHLFaj7oWzTo9tTt+noB79Ttqc4+a0lYwDqBLLJhlHU+cWgcyOP2lB6TboXH0xA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.2.0.tgz",
+      "integrity": "sha512-EToZYPGXpl42Asw3bxpX8aKmHfRUdGxKPjQ9CHZVQoTAL27Af4FyjyGnepsnDpnYdIeI8VPb2S3k2NL/1+fpIA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
-        "docker-compose": "^0.22.2",
+        "docker-compose": "^0.24.3",
         "extract-zip": "^1.6.7",
         "got": "^11.8.5",
         "inquirer": "^7.1.0",
@@ -677,6 +677,10 @@
       },
       "bin": {
         "wp-env": "bin/wp-env"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/acorn": {
@@ -1755,10 +1759,13 @@
       }
     },
     "node_modules/docker-compose": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-      "integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
       "dev": true,
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -6858,14 +6865,14 @@
       }
     },
     "@wordpress/env": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.16.0.tgz",
-      "integrity": "sha512-zx6UO8PuJBrQ34cfeedK1HlGHLFaj7oWzTo9tTt+noB79Ttqc4+a0lYwDqBLLJhlHU+cWgcyOP2lB6TboXH0xA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.2.0.tgz",
+      "integrity": "sha512-EToZYPGXpl42Asw3bxpX8aKmHfRUdGxKPjQ9CHZVQoTAL27Af4FyjyGnepsnDpnYdIeI8VPb2S3k2NL/1+fpIA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
-        "docker-compose": "^0.22.2",
+        "docker-compose": "^0.24.3",
         "extract-zip": "^1.6.7",
         "got": "^11.8.5",
         "inquirer": "^7.1.0",
@@ -7644,10 +7651,13 @@
       }
     },
     "docker-compose": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-      "integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
-      "dev": true
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+      "dev": true,
+      "requires": {
+        "yaml": "^2.2.2"
+      }
     },
     "doctrine": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/node": "^12.20.11",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
-    "@wordpress/env": "^5.5.0",
+    "@wordpress/env": "^10.2.0",
     "codecov": "^3.8.1",
     "compare-versions": "^4.1.3",
     "cypress": "^13.6.4",

--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -70,9 +70,21 @@ export const createPost = ({
   // Close Welcome Guide.
   cy.closeWelcomeGuide();
 
+  // Close Start Page Options.
+  if (postType === 'page') {
+    const modelCloseSelector =
+      '.edit-post-start-page-options__modal button[aria-label="Close"]';
+    cy.get(modelCloseSelector).then($ele => {
+      if ($ele.length > 0) {
+        cy.get(modelCloseSelector).click();
+      }
+    });
+  }
+
   // Fill out data.
   if (title.length > 0) {
-    cy.getBlockEditor().find(titleInput).clear().type(title);
+    cy.getBlockEditor().find(titleInput).clear();
+    cy.getBlockEditor().find(titleInput).type(title);
   }
 
   if (content.length > 0) {

--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -72,11 +72,13 @@ export const createPost = ({
 
   // Close Start Page Options.
   if (postType === 'page') {
-    const modelCloseSelector =
+    // eslint-disable-next-line cypress/no-unnecessary-waiting -- Wait for the modal to appear. Didn't find a better way to handle this.
+    cy.wait(500);
+    const modelSelector =
       '.edit-post-start-page-options__modal button[aria-label="Close"]';
-    cy.get(modelCloseSelector).then($ele => {
-      if ($ele.length > 0) {
-        cy.get(modelCloseSelector).click();
+    cy.get('body').then($body => {
+      if ($body.find('.edit-post-start-page-options__modal').length > 0) {
+        cy.get(modelSelector).click();
       }
     });
   }

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -95,8 +95,7 @@ export const insertBlock = (type: string, name?: string): void => {
                     `.wp-block[data-type="${ns}/${rest}"]`
                   );
                   if (blockInIframe.length > 0) {
-                    expect(blockInIframe.length).to.equal(1);
-                    cy.wrap(blockInIframe.prop('id'));
+                    cy.wrap(blockInIframe.last().prop('id'));
                   }
                 });
               } else if (

--- a/src/commands/wp-cli-eval.ts
+++ b/src/commands/wp-cli-eval.ts
@@ -23,7 +23,7 @@ export const wpCliEval = (command: string): void => {
 
     // which is read from it's proper location in the plugins directory
     cy.exec(
-      `npm --silent run env run tests-cli "eval-file wp-content/plugins/${pluginName}/${fileName}"` // eslint-disable-line @typescript-eslint/restrict-template-expressions
+      `npm --silent run env run tests-cli -- wp eval-file wp-content/plugins/${pluginName}/${fileName}` // eslint-disable-line @typescript-eslint/restrict-template-expressions
     ).then(result => {
       cy.exec(`rm ${fileName}`);
       cy.wrap(result);

--- a/src/commands/wp-cli.ts
+++ b/src/commands/wp-cli.ts
@@ -13,7 +13,7 @@
  * ```
  */
 export const wpCli = (command: string, ignoreFailures = false): void => {
-  const escapedCommand = command.replace(/"/g, '\\"');
+  const escapedCommand = command.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   const options = {
     failOnNonZeroExit: !ignoreFailures,
   };

--- a/src/commands/wp-cli.ts
+++ b/src/commands/wp-cli.ts
@@ -13,12 +13,12 @@
  * ```
  */
 export const wpCli = (command: string, ignoreFailures = false): void => {
-  const escapedCommand = command.replace(/"/g, '\\"').replace(/^wp /, '');
+  const escapedCommand = command.replace(/"/g, '\\"');
   const options = {
     failOnNonZeroExit: !ignoreFailures,
   };
   cy.exec(
-    `npm --silent run env run tests-cli "${escapedCommand}"`,
+    `npm --silent run env run tests-cli -- ${escapedCommand}`,
     options
   ).then(result => {
     cy.wrap(result);

--- a/tests/bin/initialize.sh
+++ b/tests/bin/initialize.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-npm run env run tests-wordpress "chmod -c ugo+w /var/www/html"
-npm run env run tests-cli "wp rewrite structure '/%postname%/' --hard"
+wp-env run tests-wordpress chmod -c ugo+w /var/www/html
+wp-env run tests-cli wp rewrite structure '/%postname%/' --hard
 
-npm run env run tests-cli "wp user create user1 user1@example.test --role=author --user_pass=password1"
-npm run env run tests-cli "wp user create user2 user2@example.test --role=author --user_pass=password2"
+wp-env run tests-cli wp user create user1 user1@example.test --role=author --user_pass=password1
+wp-env run tests-cli wp user create user2 user2@example.test --role=author --user_pass=password2

--- a/tests/cypress/cypress-config.js
+++ b/tests/cypress/cypress-config.js
@@ -1,5 +1,6 @@
 const { defineConfig } = require('cypress');
-const { readConfig } = require('@wordpress/env/lib/config');
+const { loadConfig } = require('@wordpress/env/lib/config');
+const getCacheDirectory = require('@wordpress/env/lib/config/get-cache-directory');
 
 module.exports = defineConfig({
   chromeWebSecurity: false,
@@ -33,7 +34,8 @@ module.exports = defineConfig({
  * @returns config Updated Cypress Config object.
  */
 const setBaseUrl = async (on, config) => {
-  const wpEnvConfig = await readConfig('wp-env');
+  const cacheDirectory = await getCacheDirectory();
+  const wpEnvConfig = await loadConfig(cacheDirectory);
 
   if (wpEnvConfig) {
     const port = wpEnvConfig.env.tests.port || null;

--- a/tests/cypress/e2e/create-post.test.js
+++ b/tests/cypress/e2e/create-post.test.js
@@ -98,15 +98,26 @@ describe('Command: createPost', () => {
           ) {
             name = 'Summary';
           }
-          cy.openDocumentSettingsPanel(name);
-        });
 
-        cy.get('label')
-          .contains('Stick to the top of the blog')
-          .click()
-          .parent()
-          .find('input[type="checkbox"]')
-          .should('be.checked');
+          // WP 6.6 handling.
+          if ($body.find('.editor-post-summary').length === 0) {
+            cy.openDocumentSettingsPanel(name);
+
+            cy.get('label')
+              .contains('Stick to the top of the blog')
+              .click()
+              .parent()
+              .find('input[type="checkbox"]')
+              .should('be.checked');
+          } else {
+            cy.get(
+              '.editor-post-sticky__toggle-control input[type="checkbox"]'
+            ).check();
+            cy.get(
+              '.editor-post-sticky__toggle-control input[type="checkbox"]'
+            ).should('be.checked');
+          }
+        });
       },
     });
 

--- a/tests/cypress/e2e/create-post.test.js
+++ b/tests/cypress/e2e/create-post.test.js
@@ -110,7 +110,12 @@ describe('Command: createPost', () => {
               .find('input[type="checkbox"]')
               .should('be.checked');
           } else {
-            cy.get('.editor-post-sticky__toggle-control').should('be.visible');
+            cy.get(
+              '.editor-post-sticky__toggle-control input[type="checkbox"]'
+            ).check();
+            cy.get(
+              '.editor-post-sticky__toggle-control input[type="checkbox"]'
+            ).should('be.checked');
           }
         });
       },

--- a/tests/cypress/e2e/create-post.test.js
+++ b/tests/cypress/e2e/create-post.test.js
@@ -110,12 +110,7 @@ describe('Command: createPost', () => {
               .find('input[type="checkbox"]')
               .should('be.checked');
           } else {
-            cy.get(
-              '.editor-post-sticky__toggle-control input[type="checkbox"]'
-            ).check();
-            cy.get(
-              '.editor-post-sticky__toggle-control input[type="checkbox"]'
-            ).should('be.checked');
+            cy.get('.editor-post-sticky__toggle-control').should('be.visible');
           }
         });
       },

--- a/tests/cypress/e2e/open-document-settings.test.js
+++ b/tests/cypress/e2e/open-document-settings.test.js
@@ -1,3 +1,4 @@
+import { compare } from 'compare-versions';
 const { randomName } = require('../support/functions');
 import { getIframe } from '../../../lib/functions/get-iframe';
 
@@ -50,15 +51,19 @@ describe('Commands: openDocumentSettings*', () => {
       ) {
         name = 'Summary';
       }
-      cy.openDocumentSettingsPanel(name);
-
-      // Assertion: Stick to the top checkbox should be visible
-      cy.get('.components-panel__body .components-panel__body-title button')
-        .contains(name, { matchCase: false })
-        .then($button => {
-          const $panel = $button.parents('.components-panel__body');
-          cy.wrap($panel).should('contain', 'Stick to the top of the blog');
-        });
+      // WP 6.6 handling.
+      if ($body.find('.editor-post-summary').length === 0) {
+        cy.openDocumentSettingsPanel(name);
+        // Assertion: Stick to the top checkbox should be visible
+        cy.get('.components-panel__body .components-panel__body-title button')
+          .contains(name, { matchCase: false })
+          .then($button => {
+            const $panel = $button.parents('.components-panel__body');
+            cy.wrap($panel).should('contain', 'Stick to the top of the blog');
+          });
+      } else {
+        cy.get('.editor-post-sticky__toggle-control').should('be.visible');
+      }
     });
   });
 
@@ -83,6 +88,11 @@ describe('Commands: openDocumentSettings*', () => {
   });
 
   it('Should be able to open Discussion panel on the existing page', () => {
+    if (compare(Cypress.env('WORDPRESS_CORE').toString(), '6.6', '>=')) {
+      assert(true, 'Skipping test');
+      return;
+    }
+
     cy.createPost({
       title: randomName(),
       postType: 'page',

--- a/tests/cypress/e2e/wp-cli.test.js
+++ b/tests/cypress/e2e/wp-cli.test.js
@@ -1,6 +1,6 @@
 describe('Command: wpCli', () => {
   it('Should run cli command and receive the response', () => {
-    cy.wpCli('cli version')
+    cy.wpCli('wp cli version')
       .its('stdout')
       .should('match', /^WP-CLI \d+\.\d+/);
   });


### PR DESCRIPTION
### Description of the Change
This PR removes the `expect` check from the insert block command. Currently, after inserting a block, we check that there is one block in the editor. However, this fails in cases where we need to add more than one block or when the editor already has blocks present and we add another block. In such cases, the block count becomes more than one, and the tests eventually fail. This PR makes changes to remove the `expect` assertion and respond with the ID from the last block.

### How to test the Change
Make sure the `insertBlock` command's E2E tests are passing.

### Changelog Entry
> Fixed - Ensure that the `insertBlock` command works properly in all cases.

### Credits
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
