### PR TITLE
Fix the `insertBlock` command on WordPress 6.8+

### DIFF
--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -39,6 +39,7 @@ export const insertBlock = (type: string, name?: string): void => {
     const selectors = [
       'button[aria-label="Add block"]', // 5.7
       'button[aria-label="Toggle block inserter"]', // 6.4
+      'button[aria-label="Block Inserter"]', // 6.8
     ];
 
     selectors.forEach(selector => {


### PR DESCRIPTION
### Description of the Change

If running WordPress trunk (which will soon become WordPress 6.8) the `insertBlock` command will fail. In investigating, it looks like the `aria-label` of the block inserter has changed, so that needs updated in our command to work.

Worth noting that since WordPress 6.8 isn't out yet, the change made to the inserter isn't guaranteed to get released but seems pretty likely. We can decide if we want to push this out prior to the release or wait until RC time to be more sure this change is needed. 

### How to test the Change

I noticed this issue initially in ClassifAI so easiest approach to test is this:

1. Checkout the `develop` branch of ClassifAI
2. Run `npm install` and then go to `node_modules/@10up/cypress-wp-utils/lib/commands/insert-block.js` and copy the one line change from this PR into that file
3. Within ClassifAI, run `npm run build && ./tests/bin/set-core-version.js WordPress/WordPress#master && npm run env:start`. This will get a test environment up and running on WordPress trunk
4. Then run `npm run cypress:open` to open Cypress
5. Within Cypress, find the `key-takeaways-openai-chatgpt.test.js` file and run it
6. Ensure all tests pass
7. You can then remove the change made to the `insert-block.js` file, run tests again and notice you have some failures now

### Changelog Entry

> Fixed - Ensure the `insertBlock` command works properly in WordPress 6.8

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
