### PR TITLE
Fix issues on WordPress 6.7 and 6.8

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -68,9 +68,23 @@ jobs:
           - {
               name: 'WP trunk',
               version: 'WordPress/WordPress#master',
+              number: 'trunk',
+            }
+          - {
+              name: 'WP 6.7',
+              version: 'WordPress/WordPress#6.7-branch',
+              number: '6.7'
+            }
+          - {
+              name: 'WP 6.6',
+              version: 'WordPress/WordPress#6.6-branch',
               number: '6.6',
             }
-          - { name: 'WP Latest', version: 'latest', number: '6.5' }
+          - {
+              name: 'WP 6.5',
+              version: 'WordPress/WordPress#6.5-branch',
+              number: '6.5',
+            }
           - {
               name: 'WP 6.4',
               version: 'WordPress/WordPress#6.4-branch',

--- a/run-all-cores.sh
+++ b/run-all-cores.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-MAJOR_VERSIONS="5.7 5.8 5.9 6.0 6.1 6.2 6.3 6.4 6.5"
-TRUNK="master:6.6"
+MAJOR_VERSIONS="5.7 5.8 5.9 6.0 6.1 6.2 6.3 6.4 6.5 6.6 6.7"
+TRUNK="master:trunk"
 
 VERSIONS=""
 for MAJOR_VERSION in $MAJOR_VERSIONS; do

--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -65,13 +65,12 @@ export const createPost = ({
   cy.visit(`/wp-admin/post-new.php?post_type=${postType}`);
 
   const titleInput = 'h1.editor-post-title__input, #post-title-0';
-  const contentInput =
-    '.block-editor-default-block-appender__content, .block-editor-inserter__toggle';
+  const contentInput = '.block-editor-default-block-appender__content';
 
   // Close Start Page Options.
   if (postType === 'page') {
     // eslint-disable-next-line cypress/no-unnecessary-waiting -- Wait for the modal to appear. Didn't find a better way to handle this.
-    cy.wait(500);
+    cy.wait(1500);
     cy.get('body').then($body => {
       if ($body.find('.edit-post-start-page-options__modal').length > 0) {
         cy.get(
@@ -86,31 +85,31 @@ export const createPost = ({
         cy.openDocumentSettingsSidebar('Post');
 
         // Switch out of template mode.
-        cy.get('body').then($body => {
-          if (
-            $body.find(
-              '.editor-post-summary button[aria-label="Template options"]'
-            ).length > 0
-          ) {
-            cy.get(
-              '.editor-post-summary button[aria-label="Template options"]'
-            ).click();
+        if (
+          $body.find(
+            '.editor-post-summary button[aria-label="Template options"]'
+          ).length > 0
+        ) {
+          cy.get(
+            '.editor-post-summary button[aria-label="Template options"]'
+          ).click();
 
-            if (
-              $body.find(
-                '.editor-post-template__dropdown button[aria-checked="true"]'
-              ).length > 0
-            ) {
-              cy.get('.editor-post-template__dropdown button')
-                .contains('Show template')
-                .click();
+          cy.get('.editor-post-template__dropdown').then($dropdown => {
+            if ($dropdown.find('button[aria-checked="true"]').length > 0) {
+              cy.get('button[aria-checked="true"]').click();
+
+              cy.reload();
+
+              cy.get(
+                '.editor-start-page-options__modal button[aria-label="Close"]'
+              ).click();
+            } else {
+              cy.get(
+                '.editor-post-summary button[aria-label="Template options"]'
+              ).click();
             }
-
-            cy.get(
-              '.editor-post-summary button[aria-label="Template options"]'
-            ).click();
-          }
-        });
+          });
+        }
       }
     });
   }
@@ -125,7 +124,7 @@ export const createPost = ({
   }
 
   if (content.length > 0) {
-    cy.getBlockEditor().find(contentInput).first().click();
+    cy.getBlockEditor().find(contentInput).click();
     cy.getBlockEditor()
       .find('.block-editor-rich-text__editable')
       .first()

--- a/src/commands/create-post.ts
+++ b/src/commands/create-post.ts
@@ -65,23 +65,58 @@ export const createPost = ({
   cy.visit(`/wp-admin/post-new.php?post_type=${postType}`);
 
   const titleInput = 'h1.editor-post-title__input, #post-title-0';
-  const contentInput = '.block-editor-default-block-appender__content';
-
-  // Close Welcome Guide.
-  cy.closeWelcomeGuide();
+  const contentInput =
+    '.block-editor-default-block-appender__content, .block-editor-inserter__toggle';
 
   // Close Start Page Options.
   if (postType === 'page') {
     // eslint-disable-next-line cypress/no-unnecessary-waiting -- Wait for the modal to appear. Didn't find a better way to handle this.
     cy.wait(500);
-    const modelSelector =
-      '.edit-post-start-page-options__modal button[aria-label="Close"]';
     cy.get('body').then($body => {
       if ($body.find('.edit-post-start-page-options__modal').length > 0) {
-        cy.get(modelSelector).click();
+        cy.get(
+          '.edit-post-start-page-options__modal button[aria-label="Close"]'
+        ).click();
+      } else if ($body.find('.editor-start-page-options__modal').length > 0) {
+        // WP 6.8+.
+        cy.get(
+          '.editor-start-page-options__modal button[aria-label="Close"]'
+        ).click();
+
+        cy.openDocumentSettingsSidebar('Post');
+
+        // Switch out of template mode.
+        cy.get('body').then($body => {
+          if (
+            $body.find(
+              '.editor-post-summary button[aria-label="Template options"]'
+            ).length > 0
+          ) {
+            cy.get(
+              '.editor-post-summary button[aria-label="Template options"]'
+            ).click();
+
+            if (
+              $body.find(
+                '.editor-post-template__dropdown button[aria-checked="true"]'
+              ).length > 0
+            ) {
+              cy.get('.editor-post-template__dropdown button')
+                .contains('Show template')
+                .click();
+            }
+
+            cy.get(
+              '.editor-post-summary button[aria-label="Template options"]'
+            ).click();
+          }
+        });
       }
     });
   }
+
+  // Close Welcome Guide.
+  cy.closeWelcomeGuide();
 
   // Fill out data.
   if (title.length > 0) {
@@ -90,7 +125,7 @@ export const createPost = ({
   }
 
   if (content.length > 0) {
-    cy.getBlockEditor().find(contentInput).click();
+    cy.getBlockEditor().find(contentInput).first().click();
     cy.getBlockEditor()
       .find('.block-editor-rich-text__editable')
       .first()

--- a/tests/cypress/e2e/create-post.test.js
+++ b/tests/cypress/e2e/create-post.test.js
@@ -109,13 +109,19 @@ describe('Command: createPost', () => {
               .parent()
               .find('input[type="checkbox"]')
               .should('be.checked');
-          } else {
+          } else if ($body.find('.editor-post-sticky__toggle-control').length) {
             cy.get(
               '.editor-post-sticky__toggle-control input[type="checkbox"]'
             ).check();
             cy.get(
               '.editor-post-sticky__toggle-control input[type="checkbox"]'
             ).should('be.checked');
+          } else if ($body.find('.editor-post-status__toggle').length) {
+            // WP 6.7+ handling.
+            cy.get('.editor-post-status__toggle').click();
+            cy.get(
+              '.editor-post-sticky__checkbox-control input[type="checkbox"]'
+            ).check();
           }
         });
       },

--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -92,7 +92,10 @@ describe('Command: insertBlock', () => {
   });
 
   it('Should be able to insert custom block', () => {
-    if (compare(Cypress.env('WORDPRESS_CORE').toString(), '6.1', '<')) {
+    if (
+      'trunk' !== Cypress.env('WORDPRESS_CORE').toString() &&
+      compare(Cypress.env('WORDPRESS_CORE').toString(), '6.1', '<')
+    ) {
       // WinAmp block does not support this version of WordPress.
       assert(true, 'Skipping test, WinAmp block does not exist');
       return;

--- a/tests/cypress/e2e/open-document-settings.test.js
+++ b/tests/cypress/e2e/open-document-settings.test.js
@@ -86,13 +86,16 @@ describe('Commands: openDocumentSettings*', () => {
         .contains(name)
         .then($button => {
           const $panel = $button.parents('.components-panel__body');
-          cy.wrap($panel).should('contain', 'Add New Tag');
+          cy.wrap($panel).should('contain', 'Add');
         });
     });
   });
 
   it('Should be able to open Discussion panel on the existing page', () => {
-    if (compare(Cypress.env('WORDPRESS_CORE').toString(), '6.6', '>=')) {
+    if (
+      'trunk' === Cypress.env('WORDPRESS_CORE').toString() ||
+      compare(Cypress.env('WORDPRESS_CORE').toString(), '6.6', '>=')
+    ) {
       assert(true, 'Skipping test');
       return;
     }

--- a/tests/cypress/e2e/open-document-settings.test.js
+++ b/tests/cypress/e2e/open-document-settings.test.js
@@ -61,8 +61,12 @@ describe('Commands: openDocumentSettings*', () => {
             const $panel = $button.parents('.components-panel__body');
             cy.wrap($panel).should('contain', 'Stick to the top of the blog');
           });
-      } else {
+      } else if ($body.find('.editor-post-sticky__toggle-control').length) {
         cy.get('.editor-post-sticky__toggle-control').should('be.visible');
+      } else if ($body.find('.editor-post-status__toggle').length) {
+        // WP 6.7+ handling.
+        cy.get('.editor-post-status__toggle').click();
+        cy.get('.editor-post-sticky__checkbox-control').should('be.visible');
       }
     });
   });

--- a/tests/cypress/e2e/plugins.test.js
+++ b/tests/cypress/e2e/plugins.test.js
@@ -12,6 +12,7 @@ describe('Plugins commands', () => {
       const winAmpMinimumVersion = '6.1';
 
       if (
+        'trunk' !== Cypress.env('WORDPRESS_CORE').toString() &&
         compare(
           Cypress.env('WORDPRESS_CORE').toString(),
           winAmpMinimumVersion,

--- a/tests/cypress/e2e/z.check-block-pattern-exists.test.js
+++ b/tests/cypress/e2e/z.check-block-pattern-exists.test.js
@@ -36,7 +36,10 @@ describe('Command: checkBlockPatternExists', () => {
           title: testCase.title,
         };
 
-        if (compare(Cypress.env('WORDPRESS_CORE').toString(), '5.7', '>=')) {
+        if (
+          'trunk' === Cypress.env('WORDPRESS_CORE').toString() ||
+          compare(Cypress.env('WORDPRESS_CORE').toString(), '5.7', '>=')
+        ) {
           args.categoryValue = testCase.cat;
         }
 

--- a/tests/cypress/e2e/z.check-block-pattern-exists.test.js
+++ b/tests/cypress/e2e/z.check-block-pattern-exists.test.js
@@ -6,7 +6,10 @@ const { randomName } = require('../support/functions');
 import { compare } from 'compare-versions';
 
 describe('Command: checkBlockPatternExists', () => {
-  if (compare(Cypress.env('WORDPRESS_CORE').toString(), '5.5', '>=')) {
+  if (
+    'trunk' === Cypress.env('WORDPRESS_CORE').toString() ||
+    compare(Cypress.env('WORDPRESS_CORE').toString(), '5.5', '>=')
+  ) {
     before(() => {
       cy.login();
       cy.deactivatePlugin('classic-editor');


### PR DESCRIPTION
### Description of the Change

After merging in #135, noticed that some E2E tests were failing on `develop`. In investigating, found a few issues that this PR fixes:

- In WordPress 6.8, the markup of the Start Page modal has changed, so code updates were needed in our `createPost` command to ensure that is closed properly
- Also in WordPress 6.8, there's a new template editing mode that is the default when creating pages. This breaks the insertion of content so we now switch that mode off when a page is created using the `createPost` command
- There were a few tests failing since WordPress 6.7 due to the sticky toggle being moved
- We weren't properly running tests on 6.7 so the matrix we run tests on has been updated. In addition, properly marking the trunk version as `trunk`, instead of hardcoding that to a version number, since the actual version number for trunk will change anytime a new release comes out

### How to test the Change

Ensure E2E tests are passing here

### Changelog Entry

> Fix - Ensure the `createPost` command works properly when used to create pages on WordPress 6.8
> Developer - Update the matrix of WordPress versions we run our E2E tests on
> Developer - Ensure all E2E tests pass on WordPress 6.7

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
