### PR TITLE
Replace all occurrences of forward slashes in block names

### DIFF
--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -18,8 +18,8 @@ import { getIframe } from '../functions/get-iframe';
 export const insertBlock = (type: string, name?: string): void => {
   const [namespace = '', ...blockNameRest] = type.split('/');
   let blockNames = [
-    blockNameRest.join('/').replace('/', '-'),
-    blockNameRest.join('/').replace('/', '\\/'),
+    blockNameRest.join('/').replace(/\//g, '-'),
+    blockNameRest.join('/').replace(/\//g, '\\/'),
   ];
 
   blockNames = blockNames.filter((x, i, a) => a.indexOf(x) == i);

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -19,7 +19,7 @@ export const insertBlock = (type: string, name?: string): void => {
   const [namespace = '', ...blockNameRest] = type.split('/');
   let blockNames = [
     blockNameRest.join('/').replace(/\//g, '-'),
-    blockNameRest.join('/').replace(/\//g, '\\/'),
+    blockNameRest.join('/').replace(/\//g, String.raw`\/`),
   ];
 
   blockNames = blockNames.filter((x, i, a) => a.indexOf(x) == i);


### PR DESCRIPTION
### Description of the Change

As described in #112, if using a block that has multiple forward slashes, like block variations, our `insertBlock` command won't properly insert those, as the selector it looks for doesn't exist.

I recently ran into this in ClassifAI and found the easiest fix was to ensure we search/replace all forward slashes, not just the first one.

Some tests are failing here but I believe these are all ones I already fixed in #136 

Closes #112

### How to test the Change

See block example on #112. Set that up locally and run a test that tries to insert that block. It should fail on the latest release and should work on this PR

### Changelog Entry

> Fixed - Ensure the `insertBlock` command works properly for blocks with multiple slashes, like block variations.

### Credits

Props @dkotter, @roseg43 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
