### PR TITLE
Update Block Tests for WP 7.0

### DIFF
--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -82,13 +82,13 @@ describe('Command: insertBlock', () => {
   it('Should be able to insert an Embed sub-block', () => {
     cy.createPost({
       beforeSave: () => {
-        cy.insertBlock('core/embed/twitter', 'Twitter');
+        cy.insertBlock('core/embed/youtube', 'YouTube');
       },
     });
 
     cy.getBlockEditor()
       .find('.wp-block-embed')
-      .should('contain.text', 'Twitter');
+      .should('contain.text', 'YouTube');
   });
 
   it('Should be able to insert custom block', () => {

--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -58,7 +58,9 @@ describe('Command: insertBlock', () => {
       beforeSave: () => {
         cy.insertBlock('core/list').then(id => {
           cy.getBlockEditor()
-            .find(`#${id} [aria-label="Block: List Item"]`)
+            .find(
+              `#${id} [aria-label="List text"], #${id}[aria-label="Block: List"]`
+            )
             .click()
             .type(`${itemOne}{enter}${itemTwo}`);
         });

--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -69,7 +69,8 @@ describe('Command: insertBlock', () => {
     });
 
     cy.getBlockEditor()
-      .find('.wp-block-list')
+      .find('.wp-block-list, [data-type="core/list"]') // [data-type="core/list"] can be removed once the minimum is above WP 5.7.
+      .first()
       .should('contain.text', itemOne)
       .should('contain.text', itemTwo);
   });

--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -61,6 +61,7 @@ describe('Command: insertBlock', () => {
             .find(
               `#${id} [aria-label="List text"], #${id}[aria-label="Block: List"]`
             )
+            .first()
             .click()
             .type(`${itemOne}{enter}${itemTwo}`);
         });

--- a/tests/cypress/e2e/insert-block.test.js
+++ b/tests/cypress/e2e/insert-block.test.js
@@ -51,32 +51,24 @@ describe('Command: insertBlock', () => {
       .should('contain.text', heading);
   });
 
-  it('Should be able to insert Pullquote', () => {
-    const quote = 'Quote ' + randomName();
-    const cite = 'Cite ' + randomName();
+  it('Should be able to insert List', () => {
+    const itemOne = 'Item One ' + randomName();
+    const itemTwo = 'Item Two ' + randomName();
     cy.createPost({
       beforeSave: () => {
-        cy.insertBlock('core/pullquote').then(id => {
+        cy.insertBlock('core/list').then(id => {
           cy.getBlockEditor()
-            .find(
-              `#${id} [aria-label="Pullquote text"], #${id} [aria-label="Write quote…"]`
-            )
+            .find(`#${id} [aria-label="Block: List Item"]`)
             .click()
-            .type(quote);
-          cy.getBlockEditor()
-            .find(
-              `#${id} [aria-label="Pullquote citation text"], #${id} [aria-label="Write citation…"]`
-            )
-            .click()
-            .type(cite);
+            .type(`${itemOne}{enter}${itemTwo}`);
         });
       },
     });
 
     cy.getBlockEditor()
-      .find('.wp-block-pullquote')
-      .should('contain.text', quote)
-      .should('contain.text', cite);
+      .find('.wp-block-list')
+      .should('contain.text', itemOne)
+      .should('contain.text', itemTwo);
   });
 
   it('Should be able to insert an Embed sub-block', () => {


### PR DESCRIPTION
### Description of the Change

Updates block insertion tests:

* Pullquote is deprecated in WP 7.0, use list block instead
* Twitter block is renamed X in WP 7.0, use YouTube to test embeds instead.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #144 

### How to test the Change

Observe whether E2E tests pass on this PR.


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Developer - Update block tests to account for block changes in WP 7.0

### Credits
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
