### PR TITLE
Add WP 6.8, 6.9 and 7.0 to test matrix.

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -71,9 +71,24 @@ jobs:
               number: 'trunk',
             }
           - {
+              name: 'WP 7.0',
+              version: 'WordPress/WordPress#7.0-branch',
+              number: '7.0',
+            }
+          - {
+              name: 'WP 6.9',
+              version: 'WordPress/WordPress#6.9-branch',
+              number: '6.9',
+            }
+          - {
+              name: 'WP 6.8',
+              version: 'WordPress/WordPress#6.8-branch',
+              number: '6.8',
+            }
+          - {
               name: 'WP 6.7',
               version: 'WordPress/WordPress#6.7-branch',
-              number: '6.7'
+              number: '6.7',
             }
           - {
               name: 'WP 6.6',

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 tests/cypress/screenshots
 tests/cypress/videos
 tests/cypress/reports
+tests/cypress/downloads
 
 # wp-env files
 .wp-env.override.json

--- a/run-all-cores.sh
+++ b/run-all-cores.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MAJOR_VERSIONS="5.7 5.8 5.9 6.0 6.1 6.2 6.3 6.4 6.5 6.6 6.7"
+MAJOR_VERSIONS="5.7 5.8 5.9 6.0 6.1 6.2 6.3 6.4 6.5 6.6 6.7 6.8 6.9 7.0"
 TRUNK="master:trunk"
 
 VERSIONS=""

--- a/src/commands/insert-block.ts
+++ b/src/commands/insert-block.ts
@@ -83,7 +83,8 @@ export const insertBlock = (type: string, name?: string): void => {
         // Start of Block insertion by click logic.
         cy.get(blockSelector).then($block => {
           if ($block.length) {
-            cy.wrap($block).click();
+            cy.wrap($block).as('block');
+            cy.get('@block').click();
             inserterBtn.click();
 
             const [ns, rest] = type.split('/'); // namespace = ns, second namespace or block name = rest

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,17 @@ declare global {
   }
 }
 
+// Ignore promises rejected due to missed transitions.
+// These are common on CI environments due to the speed of the tests and the environment.
+Cypress.on('uncaught:exception', err => {
+  if (
+    err?.name === 'AbortError' &&
+    err?.message?.includes('Transition was skipped')
+  ) {
+    return false;
+  }
+});
+
 // Register commands
 Cypress.Commands.add('checkPostExists', checkPostExists);
 Cypress.Commands.add('classicCreatePost', classicCreatePost);


### PR DESCRIPTION
### Description of the Change

Update test matrix to include WordPress 6.8 through 7.0.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Developer - Add WordPress 6.8 - 7.0 to the test matrix.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
